### PR TITLE
Remove coverage from CI builds, update ONNX version

### DIFF
--- a/.azure-pipelines/linux-conda-CI.yml
+++ b/.azure-pipelines/linux-conda-CI.yml
@@ -21,7 +21,7 @@ jobs:
 
       Python36:
         python.version: '3.6'
-        ONNX_PATH: onnx==1.4.1
+        ONNX_PATH: onnx==1.5.0
         KERAS: keras
 
       Python37:
@@ -56,11 +56,7 @@ jobs:
       python -c "import onnxruntime"
       python -c "import onnxconverter_common"
       pytest tests --doctest-modules --junitxml=junit/test-results.xml
-      pip install coverage onnx
-      coverage run --include=keras2onnx/* --omit=keras2onnx/ktf2onnx/* tests/test_layers.py
-      coverage report -m
-      coverage html
-    displayName: 'pytest + coverage'
+    displayName: 'pytest'
 
   - task: PublishTestResults@2
     inputs:

--- a/.azure-pipelines/win32-conda-CI.yml
+++ b/.azure-pipelines/win32-conda-CI.yml
@@ -21,7 +21,7 @@ jobs:
 
       Python36:
         python.version: '3.6'
-        ONNX_PATH: onnx==1.4.1
+        ONNX_PATH: onnx==1.5.0
         KERAS: keras
 
       Python37:
@@ -60,11 +60,7 @@ jobs:
       echo Test onnxruntime installation... && python -c "import onnxruntime"
       python -c "import onnxconverter_common"
       pytest tests --doctest-modules --junitxml=junit/test-results.xml
-      pip install coverage onnx
-      coverage run --include=keras2onnx/* --omit=keras2onnx/ktf2onnx/* tests/test_layers.py
-      coverage report -m
-      coverage html
-    displayName: 'pytest + coverage'
+    displayName: 'pytest'
 
   - task: PublishTestResults@2
     inputs:


### PR DESCRIPTION
* coverage is slowing down CI build times, so only keep reports in the nightly builds
* update onnx version to 1.5.0 in python 3.6 builds