### PR TITLE
Update keras2onnx opset support information

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Initially, the Keras converter was developed in the project [onnxmltools](https:
 
 All Keras layers have been supported for conversion using keras2onnx since **ONNX opset 7**. Please refer to the [Keras documentation](https://keras.io/layers/about-keras-layers/) for details on Keras layers. The keras2onnx converter also supports the lambda/custom layer by working with the [tf2onnx](https://github.com/onnx/tensorflow-onnx) converter which is embedded directly into the source tree to avoid version conflicts and installation complexity.
 
-Windows Machine Learning (WinML) users can use [WinMLTools](https://docs.microsoft.com/en-us/windows/ai/windows-ml/convert-model-winmltools) to convert their Keras models to the ONNX format. If you want to use the keras2onnx converter with WinML, refer to the [WinML Release Notes](https://docs.microsoft.com/en-us/windows/ai/windows-ml/release-notes) to identify the corresponding ONNX opset for your WinML version.
+Windows Machine Learning (WinML) users can use [WinMLTools](https://docs.microsoft.com/en-us/windows/ai/windows-ml/convert-model-winmltools) to convert their Keras models to the ONNX format. If you want to use the keras2onnx converter, please refer to the [WinML Release Notes](https://docs.microsoft.com/en-us/windows/ai/windows-ml/release-notes) to identify the corresponding ONNX opset for your WinML version.
 
 keras2onnx has been tested on **Python 3.5, 3.6, and 3.7** (CI build). It does not support **Python 2.x**.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Initially, the Keras converter was developed in the project [onnxmltools](https:
 
 All Keras layers have been supported for conversion using keras2onnx since **ONNX opset 7**. Please refer to the [Keras documentation](https://keras.io/layers/about-keras-layers/) for details on Keras layers. The keras2onnx converter also supports the lambda/custom layer by working with the [tf2onnx](https://github.com/onnx/tensorflow-onnx) converter which is embedded directly into the source tree to avoid version conflicts and installation complexity.
 
-For Windows Machine Learning (WinML) users, please refer to the [WinML Release Notes](https://docs.microsoft.com/en-us/windows/ai/windows-ml/release-notes) to identify the corresponding ONNX opset for your WinML version.
+For Windows Machine Learning (WinML) users, please use [WinMLTools](https://docs.microsoft.com/en-us/windows/ai/windows-ml/convert-model-winmltools) to convert your Keras model to the ONNX format. If you want to use the keras2onnx converter, refer to the [WinML Release Notes](https://docs.microsoft.com/en-us/windows/ai/windows-ml/release-notes) to identify the corresponding ONNX opset for your WinML version.
 
 keras2onnx has been tested on **Python 3.5, 3.6, and 3.7** (CI build). It does not support **Python 2.x**.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Initially, the Keras converter was developed in the project [onnxmltools](https:
 
 All Keras layers have been supported for conversion using keras2onnx since **ONNX opset 7**. Please refer to the [Keras documentation](https://keras.io/layers/about-keras-layers/) for details on Keras layers. The keras2onnx converter also supports the lambda/custom layer by working with the [tf2onnx](https://github.com/onnx/tensorflow-onnx) converter which is embedded directly into the source tree to avoid version conflicts and installation complexity.
 
-For Windows Machine Learning (WinML) users, please use [WinMLTools](https://docs.microsoft.com/en-us/windows/ai/windows-ml/convert-model-winmltools) to convert your Keras model to the ONNX format. If you want to use the keras2onnx converter, refer to the [WinML Release Notes](https://docs.microsoft.com/en-us/windows/ai/windows-ml/release-notes) to identify the corresponding ONNX opset for your WinML version.
+Windows Machine Learning (WinML) users can use [WinMLTools](https://docs.microsoft.com/en-us/windows/ai/windows-ml/convert-model-winmltools) to convert their Keras models to the ONNX format. If you want to use the keras2onnx converter with WinML, refer to the [WinML Release Notes](https://docs.microsoft.com/en-us/windows/ai/windows-ml/release-notes) to identify the corresponding ONNX opset for your WinML version.
 
 keras2onnx has been tested on **Python 3.5, 3.6, and 3.7** (CI build). It does not support **Python 2.x**.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 The keras2onnx model converter enables users to convert Keras models into the [ONNX](https://onnx.ai) model format.
 Initially, the Keras converter was developed in the project [onnxmltools](https://github.com/onnx/onnxmltools). [keras2onnx](https://github.com/onnx/keras-onnx) converter development was moved into a independent repository to support more kinds of Keras models and reduce the complexity of mixing multiple converters.
 
-All Keras layers have been supported for conversion using keras2onnx since ONNX opset 7. Please refer to the [Keras documentation](https://keras.io/layers/about-keras-layers/) for details on Keras layers. The keras2onnx converter also supports the lambda/custom layer by working with the [tf2onnx](https://github.com/onnx/tensorflow-onnx) converter which is embedded into the source tree directly to avoid version conflicts and installation complexity.
+All Keras layers have been supported for conversion using keras2onnx since ONNX opset 7. Please refer to the [Keras documentation](https://keras.io/layers/about-keras-layers/) for details on Keras layers. The keras2onnx converter also supports the lambda/custom layer by working with the [tf2onnx](https://github.com/onnx/tensorflow-onnx) converter which is embedded directly into the source tree to avoid version conflicts and installation complexity.
 
 For Windows Machine Learning (WinML) users, please refer to the [WinML Release Notes](https://docs.microsoft.com/en-us/windows/ai/windows-ml/release-notes) to identify the corresponding ONNX opset for your WinML version.
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@
 | [![Build Status](https://dev.azure.com/onnxmltools/ketone/_apis/build/status/linux-conda-ci?branchName=master)](https://dev.azure.com/onnxmltools/ketone/_build/latest?definitionId=9&branchName=master) | [![Build Status](https://dev.azure.com/onnxmltools/ketone/_apis/build/status/win32-conda-ci?branchName=master)](https://dev.azure.com/onnxmltools/ketone/_build/latest?definitionId=10&branchName=master) |
 
 
-# Introduction 
+# Introduction
 The keras2onnx model converter enables users to convert Keras models into the [ONNX](https://onnx.ai) model format.
-Initially, the Keras converter was developed in the project [onnxmltools](https://github.com/onnx/onnxmltools). To support more kinds of Keras models and reduce the complexity of mixing multiple converters, keras2onnx was created to convert the Keras model only.
+Initially, the Keras converter was developed in the project [onnxmltools](https://github.com/onnx/onnxmltools). The [keras2onnx](https://github.com/onnx/keras-onnx) tool was created to support more kinds of Keras models and reduce the complexity of mixing multiple converters.
 
-keras2onnx converter supports not only all keras built-in layers, but also the lambda/custom layer by working with the [tf2onnx](https://github.com/onnx/tensorflow-onnx) converter which is embedded into the source tree directly now to avoid version conflicts and installation complexity.
+All Keras layers have been supported for conversion using keras2onnx since ONNX opset 7. Please refer to the [Keras documentation](https://keras.io/layers/about-keras-layers/) for details on Keras layers. The keras2onnx converter also supports the lambda/custom layer by working with the [tf2onnx](https://github.com/onnx/tensorflow-onnx) converter which is embedded into the source tree directly to avoid version conflicts and installation complexity.
+
+For Windows Machine Learning (WinML) users, please refer to the [WinML Release Notes](https://docs.microsoft.com/en-us/windows/ai/windows-ml/release-notes) to identify the corresponding ONNX opset for your WinML version.
 
 keras2onnx has been tested on **Python 3.5, 3.6, and 3.7** (CI build). It does not support **Python 2.x**.
 
@@ -17,10 +19,10 @@ keras2onnx has been tested on **Python 3.5, 3.6, and 3.7** (CI build). It does n
 
 # tf.keras v.s. keras.io
 Both Keras model types are supported now. If keras package was installed as the one from https://keras.io/, the converter converts the model as it was created by this keras.io package, otherwise it will convert as it was by tf.keras.<br>
-If you want to override this behaviour, please specify the environment variable TF_KERAS=1 before invoking the converter python API. 
+If you want to override this behaviour, please specify the environment variable TF_KERAS=1 before invoking the converter python API.
 
 # Usage
-Before running the converter, please notice that tensorflow has to be installed in your python environment, 
+Before running the converter, please notice that tensorflow has to be installed in your python environment,
 you can choose **tensorflow** package(CPU version) or **tensorflow-gpu**(GPU version)
 ## Validate pre-trained Keras application models
 It will be useful to convert the models from Keras to ONNX from a python script.
@@ -80,7 +82,7 @@ sess = onnxruntime.InferenceSession(temp_model_file)
 
 We converted successfully for all the keras application models such as:
 Xception, VGG16, VGG19, ResNet50, InceptionV3, InceptionResNetV2, MobileNet, MobileNetV2, DenseNet121, DenseNet169, DenseNet201, NASNetMobile, and NASNetLarge.
-Try the following models and convert them to onnx using the code above. 
+Try the following models and convert them to onnx using the code above.
 
 ```
 from keras.applications.xception import Xception
@@ -124,7 +126,7 @@ model = NASNetLarge(include_top=True, weights='imagenet')
 ```
 
 ## Contribute
-We welcome contributions in the form of feedback, ideas, or code. 
+We welcome contributions in the form of feedback, ideas, or code.
 
 ## License
 [MIT License](LICENSE)

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 
 # Introduction
 The keras2onnx model converter enables users to convert Keras models into the [ONNX](https://onnx.ai) model format.
-Initially, the Keras converter was developed in the project [onnxmltools](https://github.com/onnx/onnxmltools). [keras2onnx](https://github.com/onnx/keras-onnx) converter development was moved into a independent repository to support more kinds of Keras models and reduce the complexity of mixing multiple converters.
+Initially, the Keras converter was developed in the project [onnxmltools](https://github.com/onnx/onnxmltools). keras2onnx converter development was moved into an [independent repository](https://github.com/onnx/keras-onnx) to support more kinds of Keras models and reduce the complexity of mixing multiple converters.
 
-All Keras layers have been supported for conversion using keras2onnx since ONNX opset 7. Please refer to the [Keras documentation](https://keras.io/layers/about-keras-layers/) for details on Keras layers. The keras2onnx converter also supports the lambda/custom layer by working with the [tf2onnx](https://github.com/onnx/tensorflow-onnx) converter which is embedded directly into the source tree to avoid version conflicts and installation complexity.
+All Keras layers have been supported for conversion using keras2onnx since ONNX **opset 7**. Please refer to the [Keras documentation](https://keras.io/layers/about-keras-layers/) for details on Keras layers. The keras2onnx converter also supports the lambda/custom layer by working with the [tf2onnx](https://github.com/onnx/tensorflow-onnx) converter which is embedded directly into the source tree to avoid version conflicts and installation complexity.
 
 For Windows Machine Learning (WinML) users, please refer to the [WinML Release Notes](https://docs.microsoft.com/en-us/windows/ai/windows-ml/release-notes) to identify the corresponding ONNX opset for your WinML version.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # Introduction
 The keras2onnx model converter enables users to convert Keras models into the [ONNX](https://onnx.ai) model format.
-Initially, the Keras converter was developed in the project [onnxmltools](https://github.com/onnx/onnxmltools). The [keras2onnx](https://github.com/onnx/keras-onnx) tool was created to support more kinds of Keras models and reduce the complexity of mixing multiple converters.
+Initially, the Keras converter was developed in the project [onnxmltools](https://github.com/onnx/onnxmltools). [keras2onnx](https://github.com/onnx/keras-onnx) converter development was moved into a independent repository to support more kinds of Keras models and reduce the complexity of mixing multiple converters.
 
 All Keras layers have been supported for conversion using keras2onnx since ONNX opset 7. Please refer to the [Keras documentation](https://keras.io/layers/about-keras-layers/) for details on Keras layers. The keras2onnx converter also supports the lambda/custom layer by working with the [tf2onnx](https://github.com/onnx/tensorflow-onnx) converter which is embedded into the source tree directly to avoid version conflicts and installation complexity.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 The keras2onnx model converter enables users to convert Keras models into the [ONNX](https://onnx.ai) model format.
 Initially, the Keras converter was developed in the project [onnxmltools](https://github.com/onnx/onnxmltools). keras2onnx converter development was moved into an [independent repository](https://github.com/onnx/keras-onnx) to support more kinds of Keras models and reduce the complexity of mixing multiple converters.
 
-All Keras layers have been supported for conversion using keras2onnx since ONNX **opset 7**. Please refer to the [Keras documentation](https://keras.io/layers/about-keras-layers/) for details on Keras layers. The keras2onnx converter also supports the lambda/custom layer by working with the [tf2onnx](https://github.com/onnx/tensorflow-onnx) converter which is embedded directly into the source tree to avoid version conflicts and installation complexity.
+All Keras layers have been supported for conversion using keras2onnx since **ONNX opset 7**. Please refer to the [Keras documentation](https://keras.io/layers/about-keras-layers/) for details on Keras layers. The keras2onnx converter also supports the lambda/custom layer by working with the [tf2onnx](https://github.com/onnx/tensorflow-onnx) converter which is embedded directly into the source tree to avoid version conflicts and installation complexity.
 
 For Windows Machine Learning (WinML) users, please refer to the [WinML Release Notes](https://docs.microsoft.com/en-us/windows/ai/windows-ml/release-notes) to identify the corresponding ONNX opset for your WinML version.
 


### PR DESCRIPTION
•	All keras layers have been supported since opset 7. Please refer to Keras documentation for all layers. 
•	For Windows ML users, please refer to Windows ML documentation for opset chosen. 