### PR TITLE
Fix for batchnorm attribute `axis` list case by adding transpose layer

### DIFF
--- a/keras2onnx/ke2onnx/batch_norm.py
+++ b/keras2onnx/ke2onnx/batch_norm.py
@@ -18,12 +18,12 @@ def convert_keras_batch_normalization(scope, operator, container):
         raise AttributeError('There is no input_shape or _input_shape for the operator: ' + operator.full_name)
 
     if isinstance(op.axis, list):
-            if len(op.axis) == 1:
-                axis = op.axis[0]
-            else:
-                raise AttributeError('No support for more than one axis in: ' + operator.full_name)
+        if len(op.axis) == 1:
+            axis = op.axis[0]
         else:
-            axis = op.axis
+            raise AttributeError('No support for more than one axis in: ' + operator.full_name)
+    else:
+        axis = op.axis
 
     skip_transpose = (op.axis != shape_len - 1 and op.axis != -1) or shape_len <= 2
     if not skip_transpose:

--- a/keras2onnx/ke2onnx/batch_norm.py
+++ b/keras2onnx/ke2onnx/batch_norm.py
@@ -17,6 +17,14 @@ def convert_keras_batch_normalization(scope, operator, container):
     else:
         raise AttributeError('There is no input_shape or _input_shape for the operator: ' + operator.full_name)
 
+    if isinstance(op.axis, list):
+            if len(op.axis) == 1:
+                axis = op.axis[0]
+            else:
+                raise AttributeError('No support for more than one axis in: ' + operator.full_name)
+        else:
+            axis = op.axis
+
     skip_transpose = (op.axis != shape_len - 1 and op.axis != -1) or shape_len <= 2
     if not skip_transpose:
         perm_1 = list(range(1, shape_len - 1))


### PR DESCRIPTION
Update batch norm list case as done in PR #117 
Add cosmetic changes to fit into code base

"Fix issue with BatchNormalisation layer having a list axis not adding the required Transpose layer when converting a NHWC model." - @fmannhardt