### PR TITLE
Install onnxconverter-common from source in pipelines

### DIFF
--- a/.azure-pipelines/linux-CI-keras-applications-nightly.yml
+++ b/.azure-pipelines/linux-CI-keras-applications-nightly.yml
@@ -38,6 +38,10 @@ jobs:
       pip install tensorflow
       pip install $(KERAS)
       pip install -r requirements.txt
+      git clone https://github.com/microsoft/onnxconverter-common
+      cd onnxconverter-common
+      pip install -e .
+      cd ..
       pip install -r requirements-dev.txt
       pip install -i https://test.pypi.org/simple/ ort-nightly
     displayName: 'Install dependencies'

--- a/.azure-pipelines/linux-conda-CI-tf-keras.yml
+++ b/.azure-pipelines/linux-conda-CI-tf-keras.yml
@@ -44,6 +44,10 @@ jobs:
       pip install $(ONNX_PATH)
       pip install tensorflow==1.13.1
       pip install -r requirements.txt
+      git clone https://github.com/microsoft/onnxconverter-common
+      cd onnxconverter-common
+      pip install -e .
+      cd ..
       pip install -r requirements-dev.txt
     displayName: 'Install dependencies'
 

--- a/.azure-pipelines/linux-conda-CI.yml
+++ b/.azure-pipelines/linux-conda-CI.yml
@@ -48,6 +48,10 @@ jobs:
       pip install tensorflow
       pip install $(KERAS)
       pip install -r requirements.txt
+      git clone https://github.com/microsoft/onnxconverter-common
+      cd onnxconverter-common
+      pip install -e .
+      cd ..
       pip install -r requirements-dev.txt
     displayName: 'Install dependencies'
 

--- a/.azure-pipelines/win32-CI-keras-applications-nightly.yml
+++ b/.azure-pipelines/win32-CI-keras-applications-nightly.yml
@@ -47,6 +47,10 @@ jobs:
       pip install tensorflow
       pip install %KERAS%
       pip install -r requirements.txt
+      git clone https://github.com/microsoft/onnxconverter-common
+      cd onnxconverter-common
+      pip install -e .
+      cd ..
       pip install -r requirements-dev.txt
       pip install -i https://test.pypi.org/simple/ ort-nightly
     displayName: 'Install dependencies'

--- a/.azure-pipelines/win32-conda-CI-tf-keras.yml
+++ b/.azure-pipelines/win32-conda-CI-tf-keras.yml
@@ -47,6 +47,10 @@ jobs:
       pip install %ONNX_PATH%
       pip install tensorflow==1.13.1
       pip install -r requirements.txt
+      git clone https://github.com/microsoft/onnxconverter-common
+      cd onnxconverter-common
+      pip install -e .
+      cd ..
       pip install -r requirements-dev.txt
     displayName: 'Install dependencies'
 

--- a/.azure-pipelines/win32-conda-CI.yml
+++ b/.azure-pipelines/win32-conda-CI.yml
@@ -51,6 +51,10 @@ jobs:
       pip install tensorflow
       pip install %KERAS%
       pip install -r requirements.txt
+      git clone https://github.com/microsoft/onnxconverter-common
+      cd onnxconverter-common
+      pip install -e .
+      cd ..
       pip install -r requirements-dev.txt
     displayName: 'Install dependencies'
 


### PR DESCRIPTION
+ Installing onnxconverter-common from github master in Azure CI Pipelines so changes can persist in the build without needing to publish a new package each time

Reference: https://github.com/onnx/onnxmltools/pull/320