### PR TITLE
Fix Keras->ONNX shape and BatchNorm conversion

### DIFF
--- a/keras2onnx/common/utils.py
+++ b/keras2onnx/common/utils.py
@@ -51,7 +51,7 @@ def set_logger_level(lvl):
 
 @with_variable('batch_size')
 def get_default_batch_size():
-    return 'None'
+    return 'N'
 
 
 def get_producer():

--- a/keras2onnx/common/utils.py
+++ b/keras2onnx/common/utils.py
@@ -51,7 +51,7 @@ def set_logger_level(lvl):
 
 @with_variable('batch_size')
 def get_default_batch_size():
-    return 'N'
+    return 'None'
 
 
 def get_producer():

--- a/keras2onnx/ke2onnx/batch_norm.py
+++ b/keras2onnx/ke2onnx/batch_norm.py
@@ -47,23 +47,20 @@ def convert_keras_batch_normalization(scope, operator, container):
     if not op.center:
         params.insert(1, np.zeros(params[1].shape, dtype=float))
 
-    gamma = params[0] / np.sqrt(params[3] + op.epsilon)
-    beta = params[1] - params[0] * params[2] / np.sqrt(params[3] + op.epsilon)
-
     scale_tensor_name = scope.get_unique_variable_name('scale')
-    container.add_initializer(scale_tensor_name, onnx_proto.TensorProto.FLOAT, params[0].shape, gamma)
+    container.add_initializer(scale_tensor_name, onnx_proto.TensorProto.FLOAT, params[0].shape, params[0])
     input_tensor_names.append(scale_tensor_name)
 
     bias_tensor_name = scope.get_unique_variable_name('bias')
-    container.add_initializer(bias_tensor_name, onnx_proto.TensorProto.FLOAT, params[1].shape, beta)
+    container.add_initializer(bias_tensor_name, onnx_proto.TensorProto.FLOAT, params[1].shape, params[1])
     input_tensor_names.append(bias_tensor_name)
 
     mean_tensor_name = scope.get_unique_variable_name('mean')
-    container.add_initializer(mean_tensor_name, onnx_proto.TensorProto.FLOAT, params[2].shape, 0 * params[2])
+    container.add_initializer(mean_tensor_name, onnx_proto.TensorProto.FLOAT, params[2].shape, params[2])
     input_tensor_names.append(mean_tensor_name)
 
     var_tensor_name = scope.get_unique_variable_name('var')
-    container.add_initializer(var_tensor_name, onnx_proto.TensorProto.FLOAT, params[3].shape, 1 + 0 * params[3])
+    container.add_initializer(var_tensor_name, onnx_proto.TensorProto.FLOAT, params[3].shape, params[3])
     input_tensor_names.append(var_tensor_name)
 
     epsilon = op.epsilon * 1e-3  # We use a much smaller epsilon because the original epsilon is absorbed in gamma

--- a/keras2onnx/ke2onnx/batch_norm.py
+++ b/keras2onnx/ke2onnx/batch_norm.py
@@ -63,7 +63,7 @@ def convert_keras_batch_normalization(scope, operator, container):
     container.add_initializer(var_tensor_name, onnx_proto.TensorProto.FLOAT, params[3].shape, params[3])
     input_tensor_names.append(var_tensor_name)
 
-    epsilon = op.epsilon * 1e-3  # We use a much smaller epsilon because the original epsilon is absorbed in gamma
+    epsilon = op.epsilon
     is_test = 1
     momentum = op.momentum
     spatial = 1

--- a/keras2onnx/parser.py
+++ b/keras2onnx/parser.py
@@ -20,7 +20,7 @@ from .wrapper import tf2onnx_wrap, TFNODES
 def _infer_variable_type(tensor):
     tensor_shape = []
     if tensor.shape not in (tf.TensorShape(None), tf.TensorShape([])):
-        tensor_shape = [d.value for d in tensor.shape]
+        tensor_shape = [d.value if d.value is not None else 'None' for d in tensor.shape]
 
     # Determine the tensor's element type
     tensor_type = tensor.dtype
@@ -172,7 +172,6 @@ def _on_parsing_keras_layer(graph, node_list, layer, kenode, model, varset, pref
 
     inputs = list_input_tensors(kenode)
     outputs = list_output_tensors(kenode)
-    oshapes = list_output_shapes(kenode)
 
     # This layer will be visited because its output is other layer's input
     assert len(node_list) == 0 or node_list[0] in [ts_.op for ts_ in outputs]


### PR DESCRIPTION
Problem:
- Shapes previously used None to denote free dimensions, which were translated to ONNX as 0
- BatchNorm parameters were incorrectly translated

Solution:
- Changed shape handling to use 'None' (correctly translated to 'None' in ONNX)
- Fixed BatchNorm parameter conversion to correctly carry over beta, gamma, mean, and variance

Validation:
Converted YOLOv3 Keras models to ONNX, verified much better output tensor parity between Keras and ONNX (WinML) evaluation