### PR TITLE
Set tensorflow 1.x for CI build

### DIFF
--- a/.azure-pipelines/linux-CI-keras-applications-nightly.yml
+++ b/.azure-pipelines/linux-CI-keras-applications-nightly.yml
@@ -50,7 +50,7 @@ jobs:
       conda config --set always_yes yes --set changeps1 no
       pip install $(ONNX_PATH)
       pip install h5py==2.9.0
-      pip install tensorflow
+      pip install tensorflow==1.14.0
       pip install $(KERAS)
       pip install -r requirements.txt
       git clone https://github.com/microsoft/onnxconverter-common

--- a/.azure-pipelines/linux-conda-CI-tf-keras.yml
+++ b/.azure-pipelines/linux-conda-CI-tf-keras.yml
@@ -27,7 +27,7 @@ jobs:
       Python37:
         python.version: '3.7.3'
         ONNX_PATH: onnx==1.5.0
-        TENSORFLOW_PATH: tensorflow
+        TENSORFLOW_PATH: tensorflow==1.14.0
 
     maxParallel: 3
 

--- a/.azure-pipelines/linux-conda-CI.yml
+++ b/.azure-pipelines/linux-conda-CI.yml
@@ -46,7 +46,7 @@ jobs:
       conda config --set always_yes yes --set changeps1 no
       pip install $(ONNX_PATH)
       pip install h5py==2.9.0
-      pip install tensorflow
+      pip install tensorflow==1.14.0
       pip install $(KERAS)
       pip install -r requirements.txt
       git clone https://github.com/microsoft/onnxconverter-common

--- a/.azure-pipelines/win32-CI-keras-applications-nightly.yml
+++ b/.azure-pipelines/win32-CI-keras-applications-nightly.yml
@@ -53,7 +53,7 @@ jobs:
       echo Test numpy installation... && python -c "import numpy"
       pip install %ONNX_PATH%
       pip install h5py==2.9.0
-      pip install tensorflow
+      pip install tensorflow==1.14.0
       pip install %KERAS%
       pip install -r requirements.txt
       git clone https://github.com/microsoft/onnxconverter-common

--- a/.azure-pipelines/win32-conda-CI-tf-keras.yml
+++ b/.azure-pipelines/win32-conda-CI-tf-keras.yml
@@ -27,7 +27,7 @@ jobs:
       Python37:
         python.version: '3.7'
         ONNX_PATH: onnx==1.5.0
-        TENSORFLOW_PATH: tensorflow
+        TENSORFLOW_PATH: tensorflow==1.14.0
 
     maxParallel: 3
 

--- a/.azure-pipelines/win32-conda-CI.yml
+++ b/.azure-pipelines/win32-conda-CI.yml
@@ -49,7 +49,7 @@ jobs:
       echo Test numpy installation... && python -c "import numpy"
       pip install %ONNX_PATH%
       pip install h5py==2.9.0
-      pip install tensorflow
+      pip install tensorflow==1.14.0
       pip install %KERAS%
       pip install -r requirements.txt
       git clone https://github.com/microsoft/onnxconverter-common

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ All Keras layers have been supported for conversion using keras2onnx since **ONN
 
 Windows Machine Learning (WinML) users can use [WinMLTools](https://docs.microsoft.com/en-us/windows/ai/windows-ml/convert-model-winmltools) to convert their Keras models to the ONNX format. If you want to use the keras2onnx converter, please refer to the [WinML Release Notes](https://docs.microsoft.com/en-us/windows/ai/windows-ml/release-notes) to identify the corresponding ONNX opset for your WinML version.
 
-keras2onnx has been tested on **Python 3.5, 3.6, and 3.7** (CI build). It does not support **Python 2.x**.
+keras2onnx has been tested on **Python 3.5, 3.6, and 3.7**, with **tensorflow 1.x** (CI build). It does not support **Python 2.x**.
 
 # Notes
 


### PR DESCRIPTION
tensorflow 2.0.0 is published, set to tf 1.x for CI build now.