### PR TITLE
Convert Keras Flatten Layer to ONNX Flatten Op

### DIFF
--- a/keras2onnx/ke2onnx/main.py
+++ b/keras2onnx/ke2onnx/main.py
@@ -6,32 +6,32 @@
 from collections.abc import Iterable
 
 import numpy as np
+from ..proto import keras, is_tf_keras, is_keras_older_than
+from ..proto.tfcompat import is_tf2
+from ..common import with_variable, k2o_logger
+from ..common.onnx_ops import apply_identity, apply_tile
+from ..common.onnx_ops import apply_reshape, apply_concat, apply_transpose, OnnxOperatorBuilder
 
 from .activation import convert_keras_activation
 from .adv_activation import convert_keras_advanced_activation
 from .batch_norm import convert_keras_batch_normalization
-from .bidirectional import convert_bidirectional
+from .merge import convert_keras_merge_layer
+from .dense import convert_keras_dense
+from .dot import convert_keras_dot
+from .upsample import convert_keras_upsample_1d, convert_keras_upsample_2d, convert_keras_upsample_3d
 from .conv import convert_keras_conv1d, convert_keras_conv2d, convert_keras_conv3d
 from .conv import convert_keras_conv_transpose_2d, convert_keras_conv_transpose_3d, convert_keras_depthwise_conv_2d
 from .conv import convert_keras_separable_conv1d, convert_keras_separable_conv2d
+from .pooling import convert_keras_max_pooling_1d, convert_keras_max_pooling_2d, convert_keras_max_pooling_3d
+from .pooling import convert_keras_average_pooling_1d, convert_keras_average_pooling_2d, \
+    convert_keras_average_pooling_3d
 from .crop import convert_keras_crop_1d, convert_keras_crop_2d, convert_keras_crop_3d
-from .dense import convert_keras_dense
-from .dot import convert_keras_dot
+from .zeropad import convert_keras_zero_pad_1d, convert_keras_zero_pad_2d, convert_keras_zero_pad_3d
 from .embedding import convert_keras_embed
+from .simplernn import convert_keras_simple_rnn
 from .gru import convert_keras_gru
 from .lstm import convert_keras_lstm
-from .merge import convert_keras_merge_layer
-from .pooling import (convert_keras_average_pooling_1d, convert_keras_average_pooling_2d,
-                      convert_keras_average_pooling_3d, convert_keras_max_pooling_1d, convert_keras_max_pooling_2d,
-                      convert_keras_max_pooling_3d)
-from .simplernn import convert_keras_simple_rnn
-from .upsample import convert_keras_upsample_1d, convert_keras_upsample_2d, convert_keras_upsample_3d
-from .zeropad import convert_keras_zero_pad_1d, convert_keras_zero_pad_2d, convert_keras_zero_pad_3d
-from ..common import with_variable, k2o_logger
-from ..common.onnx_ops import apply_identity, apply_tile
-from ..common.onnx_ops import apply_reshape, apply_concat, apply_transpose, OnnxOperatorBuilder
-from ..proto import keras, is_tf_keras, is_keras_older_than
-from ..proto.tfcompat import is_tf2
+from .bidirectional import convert_bidirectional
 
 
 def extract_inbound_nodes(layer):

--- a/keras2onnx/ke2onnx/main.py
+++ b/keras2onnx/ke2onnx/main.py
@@ -91,12 +91,8 @@ def convert_keras_concat(scope, operator, container):
 
 def convert_keras_flatten(scope, operator, container):
     iop = operator.raw_operator
-    target_shape = 1
-    for idx, val in enumerate(iop.output_shape):
-        if idx > 0:
-            target_shape = target_shape * val
-    target_shape = (-1, target_shape)
     shape_len = len(iop.input_shape)
+
     if iop.data_format == 'channels_last' or shape_len < 3:
         _apply_flatten(scope, operator.inputs[0].full_name, operator.outputs[0].full_name, container,
                        operator_name=operator.raw_operator.name)
@@ -106,8 +102,8 @@ def convert_keras_flatten(scope, operator, container):
         input_tensor_name = scope.get_unique_variable_name(operator.inputs[0].full_name + '_permuted')
         apply_transpose(scope, operator.inputs[0].full_name, input_tensor_name, container,
                         operator_name=operator.raw_operator.name + "_transpose", perm=perm)
-        apply_reshape(scope, input_tensor_name, operator.outputs[0].full_name, container,
-                      operator_name=operator.raw_operator.name, desired_shape=target_shape)
+        _apply_flatten(scope, input_tensor_name, operator.outputs[0].full_name, container,
+                       operator_name=operator.raw_operator.name)
 
 
 # TODO: This function should be moved to onnxconverter_common.onnx_ops

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -9,7 +9,7 @@ import keras2onnx
 import numpy as np
 from keras2onnx.proto.tfcompat import is_tf2, tensorflow as tf
 from keras2onnx.proto import keras, is_tf_keras, get_opset_number_from_onnx, is_keras_older_than, is_keras_later_than
-from test_utils import run_onnx_runtime
+from .test_utils import run_onnx_runtime
 
 K = keras.backend
 Activation = keras.layers.Activation

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -9,7 +9,7 @@ import keras2onnx
 import numpy as np
 from keras2onnx.proto.tfcompat import is_tf2, tensorflow as tf
 from keras2onnx.proto import keras, is_tf_keras, get_opset_number_from_onnx, is_keras_older_than, is_keras_later_than
-from .test_utils import run_onnx_runtime
+from test_utils import run_onnx_runtime
 
 K = keras.backend
 Activation = keras.layers.Activation


### PR DESCRIPTION
The current implementation uses an ONNX Reshape Op, which is causing an issue when converting from ONNX to TF to TFLite.

IMO, using a Flatten Op simplifies the graph's structure, and it's a widely supported Op.