### PR TITLE
Add keras-tcn to nightly build

### DIFF
--- a/.azure-pipelines/linux-CI-keras-applications-nightly.yml
+++ b/.azure-pipelines/linux-CI-keras-applications-nightly.yml
@@ -71,6 +71,7 @@ jobs:
       git clone https://github.com/qqwweee/keras-yolo3
       $(INSTALL_KERAS_RESNET)
       pip install git+https://www.github.com/keras-team/keras-contrib.git
+      pip install keras-tcn
     displayName: 'Install dependencies'
 
   - script: |

--- a/.azure-pipelines/win32-CI-keras-applications-nightly.yml
+++ b/.azure-pipelines/win32-CI-keras-applications-nightly.yml
@@ -69,6 +69,7 @@ jobs:
       git clone https://github.com/qqwweee/keras-yolo3
       %INSTALL_KERAS_RESNET%
       pip install git+https://www.github.com/keras-team/keras-contrib.git
+      pip install keras-tcn
     displayName: 'Install dependencies'
 
   - script: |

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ We converted successfully for all the keras application models, and several othe
 | [Segnet, VGG-Segnet](https://github.com/divamgupta/image-segmentation-keras/blob/master/keras_segmentation/models/segnet.py) | Computer Vision |
 | [UNet](https://github.com/divamgupta/image-segmentation-keras/blob/master/keras_segmentation/models/unet.py) | Computer Vision |
 | [LPCNet](https://github.com/mozilla/LPCNet) | Speech |
+| [Temporal Convolutional Network](https://github.com/philipperemy/keras-tcn) | Time sequence |
 | [ACGAN (Auxiliary Classifier GAN)](https://github.com/eriklindernoren/Keras-GAN/blob/master/acgan/acgan.py) | GAN |
 | [Adversarial Autoencoder](https://github.com/eriklindernoren/Keras-GAN/blob/master/aae/aae.py) | GAN |
 | [BGAN (Boundary-Seeking GAN)](https://github.com/eriklindernoren/Keras-GAN/blob/master/bgan/bgan.py) | GAN |

--- a/applications/nightly_build/test_keras_applications.py
+++ b/applications/nightly_build/test_keras_applications.py
@@ -123,6 +123,20 @@ class TestKerasApplications(unittest.TestCase):
         expected = model.predict(data)
         self.assertTrue(run_onnx_runtime(onnx_model.graph.name, onnx_model, data, expected, self.model_files))
 
+    def test_tcn(self):
+        from tcn import TCN
+        batch_size, timesteps, input_dim = None, 20, 1
+        i = Input(batch_shape=(batch_size, timesteps, input_dim))
+        for return_sequences in [True, False]:
+            o = TCN(return_sequences=return_sequences)(i)  # The TCN layers are here.
+            o = Dense(1)(o)
+            model = keras.models.Model(inputs=[i], outputs=[o])
+            onnx_model = keras2onnx.convert_keras(model, model.name)
+            batch_size = 3
+            data = np.random.rand(batch_size, timesteps, input_dim).astype(np.float32).reshape((batch_size, timesteps, input_dim))
+            expected = model.predict(data)
+            self.assertTrue(run_onnx_runtime(onnx_model.graph.name, onnx_model, data, expected, self.model_files))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,101 +15,7 @@ from onnx import onnx_pb, helper
 working_path = os.path.abspath(os.path.dirname(__file__))
 tmp_path = os.path.join(working_path, 'temp')
 
-
-def print_mismatches(case_name, list_idx, expected_list, actual_list, rtol=1.e-3, atol=1.e-6):
-    diff_list = abs(expected_list - actual_list)
-    count_total = len(expected_list)
-    count_error = 0
-
-    for e_, a_, d_ in zip(expected_list, actual_list, diff_list):
-        if d_ > atol + rtol * abs(a_):
-            if count_error < 10:  # print the first 10 mismatches
-                print(
-                    "case = " + case_name + ", result mismatch for expected = " + str(e_) +
-                    ", actual = " + str(a_), file=sys.stderr)
-            count_error = count_error + 1
-
-    print("case = " + case_name + ", " +
-          str(count_error) + " mismatches out of " + str(count_total) + " for list " + str(list_idx),
-          file=sys.stderr)
-
-
-def run_onnx_runtime(case_name, onnx_model, data, expected, model_files, rtol=1.e-3, atol=1.e-6):
-    if not os.path.exists(tmp_path):
-        os.mkdir(tmp_path)
-    temp_model_file = os.path.join(tmp_path, 'temp_' + case_name + '.onnx')
-    onnx.save_model(onnx_model, temp_model_file)
-    try:
-        import onnxruntime
-        sess = onnxruntime.InferenceSession(temp_model_file)
-    except ImportError:
-        return True
-
-    if isinstance(data, dict):
-        feed_input = data
-    else:
-        data = data if isinstance(data, list) else [data]
-        input_names = sess.get_inputs()
-        # to avoid too complicated test code, we restrict the input name in Keras test cases must be
-        # in alphabetical order. It's always true unless there is any trick preventing that.
-        feed = zip(sorted(i_.name for i_ in input_names), data)
-        feed_input = dict(feed)
-    actual = sess.run(None, feed_input)
-
-    if expected is None:
-        return
-
-    if not isinstance(expected, list):
-        expected = [expected]
-
-    res = all(np.allclose(expected[n_], actual[n_], rtol=rtol, atol=atol) for n_ in range(len(expected)))
-
-    if res and temp_model_file not in model_files:  # still keep the failed case files for the diagnosis.
-        model_files.append(temp_model_file)
-
-    if not res:
-        for n_ in range(len(expected)):
-            expected_list = expected[n_].flatten()
-            actual_list = actual[n_].flatten()
-            print_mismatches(case_name, n_, expected_list, actual_list, rtol, atol)
-
-    return res
-
-
-def run_image(model, model_files, img_path, model_name='onnx_conversion', rtol=1.e-3, atol=1.e-5, color_mode="rgb",
-              target_size=224):
-    preprocess_input = keras.applications.resnet50.preprocess_input
-    image = keras.preprocessing.image
-
-    try:
-        if not isinstance(target_size, tuple):
-            target_size = (target_size, target_size)
-        if is_keras_older_than("2.2.3"):
-            # color_mode is not supported in old keras version
-            img = image.load_img(img_path, target_size=target_size)
-        else:
-            img = image.load_img(img_path, color_mode=color_mode, target_size=target_size)
-        x = image.img_to_array(img)
-        x = np.expand_dims(x, axis=0)
-        if color_mode == "rgb":
-            x = preprocess_input(x)
-    except FileNotFoundError:
-        return False, 'The image data does not exist.'
-
-    msg = ''
-    preds = None
-    try:
-        preds = model.predict(x)
-    except RuntimeError:
-        msg = 'keras prediction throws an exception for model ' + model.name + ', skip comparison.'
-
-    onnx_model = keras2onnx.convert_keras(model, model.name)
-    res = run_onnx_runtime(model_name, onnx_model, x, preds, model_files, rtol=rtol, atol=atol)
-    return res, msg
-
-
 tf2onnx = keras2onnx.wrapper.tf2onnx
-
 
 # This is for Pad opset 11 which is now a contrib op, TODO: need onnx schema update for Pad
 def on_Pad(ctx, node, name, args):
@@ -237,3 +143,95 @@ tf2onnx_contrib_op_conversion = {
     'Pad': (on_Pad, []),
     'PadV2': (on_Pad, [])
 }
+
+
+def print_mismatches(case_name, list_idx, expected_list, actual_list, rtol=1.e-3, atol=1.e-6):
+    diff_list = abs(expected_list - actual_list)
+    count_total = len(expected_list)
+    count_error = 0
+
+    for e_, a_, d_ in zip(expected_list, actual_list, diff_list):
+        if d_ > atol + rtol * abs(a_):
+            if count_error < 10:  # print the first 10 mismatches
+                print(
+                    "case = " + case_name + ", result mismatch for expected = " + str(e_) +
+                    ", actual = " + str(a_), file=sys.stderr)
+            count_error = count_error + 1
+
+    print("case = " + case_name + ", " +
+          str(count_error) + " mismatches out of " + str(count_total) + " for list " + str(list_idx),
+          file=sys.stderr)
+
+
+def run_onnx_runtime(case_name, onnx_model, data, expected, model_files, rtol=1.e-3, atol=1.e-6):
+    if not os.path.exists(tmp_path):
+        os.mkdir(tmp_path)
+    temp_model_file = os.path.join(tmp_path, 'temp_' + case_name + '.onnx')
+    onnx.save_model(onnx_model, temp_model_file)
+    try:
+        import onnxruntime
+        sess = onnxruntime.InferenceSession(temp_model_file)
+    except ImportError:
+        return True
+
+    if isinstance(data, dict):
+        feed_input = data
+    else:
+        data = data if isinstance(data, list) else [data]
+        input_names = sess.get_inputs()
+        # to avoid too complicated test code, we restrict the input name in Keras test cases must be
+        # in alphabetical order. It's always true unless there is any trick preventing that.
+        feed = zip(sorted(i_.name for i_ in input_names), data)
+        feed_input = dict(feed)
+    actual = sess.run(None, feed_input)
+
+    if expected is None:
+        return
+
+    if not isinstance(expected, list):
+        expected = [expected]
+
+    res = all(np.allclose(expected[n_], actual[n_], rtol=rtol, atol=atol) for n_ in range(len(expected)))
+
+    if res and temp_model_file not in model_files:  # still keep the failed case files for the diagnosis.
+        model_files.append(temp_model_file)
+
+    if not res:
+        for n_ in range(len(expected)):
+            expected_list = expected[n_].flatten()
+            actual_list = actual[n_].flatten()
+            print_mismatches(case_name, n_, expected_list, actual_list, rtol, atol)
+
+    return res
+
+
+def run_image(model, model_files, img_path, model_name='onnx_conversion', rtol=1.e-3, atol=1.e-5, color_mode="rgb",
+              target_size=224):
+    preprocess_input = keras.applications.resnet50.preprocess_input
+    image = keras.preprocessing.image
+
+    try:
+        if not isinstance(target_size, tuple):
+            target_size = (target_size, target_size)
+        if is_keras_older_than("2.2.3"):
+            # color_mode is not supported in old keras version
+            img = image.load_img(img_path, target_size=target_size)
+        else:
+            img = image.load_img(img_path, color_mode=color_mode, target_size=target_size)
+        x = image.img_to_array(img)
+        x = np.expand_dims(x, axis=0)
+        if color_mode == "rgb":
+            x = preprocess_input(x)
+    except FileNotFoundError:
+        return False, 'The image data does not exist.'
+
+    msg = ''
+    preds = None
+    try:
+        preds = model.predict(x)
+    except RuntimeError:
+        msg = 'keras prediction throws an exception for model ' + model.name + ', skip comparison.'
+
+    onnx_model = keras2onnx.convert_keras(model, model.name)
+    res = run_onnx_runtime(model_name, onnx_model, x, preds, model_files, rtol=rtol, atol=atol)
+    return res, msg


### PR DESCRIPTION
1. Add keras-tcn to nightly build
2. Move tf2onnx_contrib_op_conversion before run_onnx_runtime in test_utils (so that we can use it in unit test).