### PR TITLE
Use keras-tcn==2.8.3

### DIFF
--- a/.azure-pipelines/linux-CI-keras-applications-nightly.yml
+++ b/.azure-pipelines/linux-CI-keras-applications-nightly.yml
@@ -71,7 +71,7 @@ jobs:
       git clone https://github.com/qqwweee/keras-yolo3
       $(INSTALL_KERAS_RESNET)
       pip install git+https://www.github.com/keras-team/keras-contrib.git
-      pip install keras-tcn
+      pip install keras-tcn==2.8.3
     displayName: 'Install dependencies'
 
   - script: |

--- a/.azure-pipelines/win32-CI-keras-applications-nightly.yml
+++ b/.azure-pipelines/win32-CI-keras-applications-nightly.yml
@@ -69,7 +69,7 @@ jobs:
       git clone https://github.com/qqwweee/keras-yolo3
       %INSTALL_KERAS_RESNET%
       pip install git+https://www.github.com/keras-team/keras-contrib.git
-      pip install keras-tcn
+      pip install keras-tcn==2.8.3
     displayName: 'Install dependencies'
 
   - script: |

--- a/applications/nightly_build/test_keras_applications.py
+++ b/applications/nightly_build/test_keras_applications.py
@@ -126,14 +126,14 @@ class TestKerasApplications(unittest.TestCase):
     def test_tcn(self):
         from tcn import TCN
         batch_size, timesteps, input_dim = None, 20, 1
+        actual_batch_size = 3
         i = Input(batch_shape=(batch_size, timesteps, input_dim))
         for return_sequences in [True, False]:
             o = TCN(return_sequences=return_sequences)(i)  # The TCN layers are here.
             o = Dense(1)(o)
             model = keras.models.Model(inputs=[i], outputs=[o])
             onnx_model = keras2onnx.convert_keras(model, model.name)
-            batch_size = 3
-            data = np.random.rand(batch_size, timesteps, input_dim).astype(np.float32).reshape((batch_size, timesteps, input_dim))
+            data = np.random.rand(actual_batch_size, timesteps, input_dim).astype(np.float32).reshape((actual_batch_size, timesteps, input_dim))
             expected = model.predict(data)
             self.assertTrue(run_onnx_runtime(onnx_model.graph.name, onnx_model, data, expected, self.model_files))
 


### PR DESCRIPTION
keras-tcn==2.9.2 breaks our nightly build, see the issue [here](https://github.com/philipperemy/keras-tcn/issues/109). Use version 2.8.3.