### PR TITLE
Masking RNN with zeros input

### DIFF
--- a/keras2onnx/ke2onnx/gru.py
+++ b/keras2onnx/ke2onnx/gru.py
@@ -96,7 +96,7 @@ def convert_keras_gru(scope, operator, container):
     oopb = OnnxOperatorBuilder(container, scope)
 
     if uses_masking_layer:
-        mask_cast = oopb.add_node('Cast', operator.input_masks[0].full_name, operator.full_name + '_mask_cast', to=oopb.int32)
+        mask_cast = oopb.apply_cast(operator.input_masks[0].full_name, to=oopb.int32, name=operator.full_name + '_mask_cast')
         oopb.add_node_with_output('ReduceSum', mask_cast, sequence_lengths, keepdims=False, axes=[-1], name=operator.full_name + '_mask_sum')
 
 

--- a/keras2onnx/ke2onnx/gru.py
+++ b/keras2onnx/ke2onnx/gru.py
@@ -50,7 +50,13 @@ def convert_keras_gru(scope, operator, container):
         gru_input_names.append('')
 
     # sequence lens
-    gru_input_names.append('')
+    uses_masking_layer = len(operator.input_masks) == 1
+    if uses_masking_layer:
+        # Mask using sequence_lens input
+        sequence_lengths = scope.get_unique_variable_name(operator.full_name + '_seq_lens')
+        gru_input_names.append(sequence_lengths)
+    else:
+        gru_input_names.append('')
     # inital_h
     if len(operator.inputs) == 1:
         gru_input_names.append('')
@@ -88,6 +94,12 @@ def convert_keras_gru(scope, operator, container):
     gru_h_name = scope.get_unique_variable_name('gru_h')
     gru_output_names = [gru_y_name, gru_h_name]
     oopb = OnnxOperatorBuilder(container, scope)
+
+    if uses_masking_layer:
+        mask_cast = oopb.add_node('Cast', operator.input_masks[0].full_name, operator.full_name + '_mask_cast', to=oopb.int32)
+        oopb.add_node_with_output('ReduceSum', mask_cast, sequence_lengths, keepdims=False, axes=[-1], name=operator.full_name + '_mask_sum')
+
+
     oopb.apply_op_with_output('apply_gru',
                               gru_input_names,
                               gru_output_names,

--- a/keras2onnx/ke2onnx/lstm.py
+++ b/keras2onnx/ke2onnx/lstm.py
@@ -157,7 +157,7 @@ def convert_keras_lstm(scope, operator, container):
     oopb = OnnxOperatorBuilder(container, scope)
 
     if uses_masking_layer:
-        mask_cast = oopb.add_node('Cast', operator.input_masks[0].full_name, operator.full_name + '_mask_cast', to=oopb.int32)
+        mask_cast = oopb.apply_cast(operator.input_masks[0].full_name, to=oopb.int32, name=operator.full_name + '_mask_cast')
         oopb.add_node_with_output('ReduceSum', mask_cast, sequence_lengths, keepdims=False, axes=[-1], name=operator.full_name + '_mask_sum')
 
     oopb.apply_op_with_output('apply_lstm',

--- a/keras2onnx/ke2onnx/lstm.py
+++ b/keras2onnx/ke2onnx/lstm.py
@@ -92,7 +92,13 @@ def convert_keras_lstm(scope, operator, container):
         lstm_input_names.append('')
 
     # sequence_lens
-    lstm_input_names.append('')
+    uses_masking_layer = len(operator.input_masks) == 1
+    if uses_masking_layer:
+        # Mask using sequence_lens input
+        sequence_lengths = scope.get_unique_variable_name(operator.full_name + '_seq_lens')
+        lstm_input_names.append(sequence_lengths)
+    else:
+        lstm_input_names.append('')
     # inital_h
     if len(operator.inputs) <= 1:
         lstm_input_names.append('')
@@ -149,6 +155,11 @@ def convert_keras_lstm(scope, operator, container):
     lstm_output_names.append(lstm_c_name)
 
     oopb = OnnxOperatorBuilder(container, scope)
+
+    if uses_masking_layer:
+        mask_cast = oopb.add_node('Cast', operator.input_masks[0].full_name, operator.full_name + '_mask_cast', to=oopb.int32)
+        oopb.add_node_with_output('ReduceSum', mask_cast, sequence_lengths, keepdims=False, axes=[-1], name=operator.full_name + '_mask_sum')
+
     oopb.apply_op_with_output('apply_lstm',
                               lstm_input_names,
                               lstm_output_names,

--- a/keras2onnx/ke2onnx/main.py
+++ b/keras2onnx/ke2onnx/main.py
@@ -79,7 +79,7 @@ def _apply_not_equal(oopb, target_opset, operator):
         k2o_logger().warning("On converting a model with opset < 11, " +
                              "the masking layer result may be incorrect if the model input is in range (0, 1.0).")
         equal_input_0 = oopb.add_node('Cast', [operator.inputs[0].full_name],
-                                      operator.full_name + '_input_cast', to=6)
+                                      operator.full_name + '_input_cast', to=oopb.int32)
         equal_out = oopb.add_node('Equal', [equal_input_0, np.array([operator.mask_value], dtype='int32')],
                                   operator.full_name + 'mask')
         not_o = oopb.add_node('Not', equal_out,

--- a/keras2onnx/ke2onnx/simplernn.py
+++ b/keras2onnx/ke2onnx/simplernn.py
@@ -85,7 +85,7 @@ def convert_keras_simple_rnn(scope, operator, container):
     oopb = OnnxOperatorBuilder(container, scope)
 
     if uses_masking_layer:
-        mask_cast = oopb.add_node('Cast', operator.input_masks[0].full_name, operator.full_name + '_mask_cast', to=oopb.int32)
+        mask_cast = oopb.apply_cast(operator.input_masks[0].full_name, to=oopb.int32, name=operator.full_name + '_mask_cast')
         oopb.add_node_with_output('ReduceSum', mask_cast, sequence_lengths, keepdims=False, axes=[-1], name=operator.full_name + '_mask_sum')
 
     oopb.apply_op_with_output('apply_rnn',

--- a/keras2onnx/ke2onnx/simplernn.py
+++ b/keras2onnx/ke2onnx/simplernn.py
@@ -48,7 +48,13 @@ def convert_keras_simple_rnn(scope, operator, container):
         rnn_input_names.append('')
 
     # sequence_lens is not able to be converted from input_length
-    rnn_input_names.append('')
+    uses_masking_layer = len(operator.input_masks) == 1
+    if uses_masking_layer:
+        # Mask using sequence_lens input
+        sequence_lengths = scope.get_unique_variable_name(operator.full_name + '_seq_lens')
+        rnn_input_names.append(sequence_lengths)
+    else:
+        rnn_input_names.append('')
     # inital_h: none
     if len(operator.inputs) == 1:
         rnn_input_names.append('')
@@ -77,6 +83,11 @@ def convert_keras_simple_rnn(scope, operator, container):
     rnn_output_names.append(rnn_y_name)
     rnn_output_names.append(rnn_h_name)
     oopb = OnnxOperatorBuilder(container, scope)
+
+    if uses_masking_layer:
+        mask_cast = oopb.add_node('Cast', operator.input_masks[0].full_name, operator.full_name + '_mask_cast', to=oopb.int32)
+        oopb.add_node_with_output('ReduceSum', mask_cast, sequence_lengths, keepdims=False, axes=[-1], name=operator.full_name + '_mask_sum')
+
     oopb.apply_op_with_output('apply_rnn',
                               rnn_input_names,
                               rnn_output_names,

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1800,7 +1800,7 @@ class TestKerasTF2ONNX(unittest.TestCase):
 
             x = np.random.uniform(100, 999, size=(2, 3, 5)).astype(np.float32)
             # Fill one of the entries with all zeros
-            x[1, :, :] = 0
+            x[1, 1:, :] = 0
 
             # Test with the default bias
             expected = model.predict(x)

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1799,7 +1799,7 @@ class TestKerasTF2ONNX(unittest.TestCase):
             ])
 
             x = np.random.uniform(100, 999, size=(2, 3, 5)).astype(np.float32)
-            # Fill one of the entries with all zeros
+            # Fill one of the entries with all zeros except the first timestep
             x[1, 1:, :] = 0
 
             # Test with the default bias

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1790,31 +1790,33 @@ class TestKerasTF2ONNX(unittest.TestCase):
 
     @unittest.skipIf(is_tf2 and is_tf_keras, 'TODO')
     def test_masking_bias(self):
-        timesteps, features = (3, 5)
-        model = Sequential([
-            keras.layers.Masking(mask_value=0., input_shape=(timesteps, features)),
-            LSTM(8, return_state=False, return_sequences=False, use_bias=True, name='rnn')
-        ])
+        for rnn_class in [LSTM, GRU, SimpleRNN]:
 
-        x = np.random.uniform(100, 999, size=(2, 3, 5)).astype(np.float32)
-        # Fill one of the entries with all zeros
-        x[1, :, :] = 0
+            timesteps, features = (3, 5)
+            model = Sequential([
+                keras.layers.Masking(mask_value=0., input_shape=(timesteps, features)),
+                rnn_class(8, return_state=False, return_sequences=False, use_bias=True, name='rnn')
+            ])
 
-        # Test with the default bias
-        expected = model.predict(x)
-        onnx_model = keras2onnx.convert_keras(model, model.name)
-        self.assertTrue(run_onnx_runtime(onnx_model.graph.name, onnx_model, x, expected, self.model_files))
+            x = np.random.uniform(100, 999, size=(2, 3, 5)).astype(np.float32)
+            # Fill one of the entries with all zeros
+            x[1, :, :] = 0
 
-        # Set bias values to random floats
-        rnn_layer = model.get_layer('rnn')
-        weights = rnn_layer.get_weights()
-        weights[2] = np.random.uniform(size=weights[2].shape)
-        rnn_layer.set_weights(weights)
+            # Test with the default bias
+            expected = model.predict(x)
+            onnx_model = keras2onnx.convert_keras(model, model.name)
+            self.assertTrue(run_onnx_runtime(onnx_model.graph.name, onnx_model, x, expected, self.model_files))
 
-        # Test with random bias
-        expected = model.predict(x)
-        onnx_model = keras2onnx.convert_keras(model, model.name)
-        self.assertTrue(run_onnx_runtime(onnx_model.graph.name, onnx_model, x, expected, self.model_files))
+            # Set bias values to random floats
+            rnn_layer = model.get_layer('rnn')
+            weights = rnn_layer.get_weights()
+            weights[2] = np.random.uniform(size=weights[2].shape)
+            rnn_layer.set_weights(weights)
+
+            # Test with random bias
+            expected = model.predict(x)
+            onnx_model = keras2onnx.convert_keras(model, model.name)
+            self.assertTrue(run_onnx_runtime(onnx_model.graph.name, onnx_model, x, expected, self.model_files))
 
     @unittest.skipIf(is_tf2 and is_tf_keras, 'TODO')
     def test_masking_value(self):

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1797,9 +1797,11 @@ class TestKerasTF2ONNX(unittest.TestCase):
         ])
 
         x = np.random.uniform(100, 999, size=(2, 3, 5)).astype(np.float32)
-        expected = model.predict(x)
+        # Fill one of the entries with all zeros
+        x[1, :, :] = 0
 
         # Test with the default bias
+        expected = model.predict(x)
         onnx_model = keras2onnx.convert_keras(model, model.name)
         self.assertTrue(run_onnx_runtime(onnx_model.graph.name, onnx_model, x, expected, self.model_files))
 
@@ -1809,10 +1811,8 @@ class TestKerasTF2ONNX(unittest.TestCase):
         weights[2] = np.random.uniform(size=weights[2].shape)
         rnn_layer.set_weights(weights)
 
-        # Fill one of the entries with all zeros
-        x[1, :, :] = 0
+        # Test with random bias
         expected = model.predict(x)
-
         onnx_model = keras2onnx.convert_keras(model, model.name)
         self.assertTrue(run_onnx_runtime(onnx_model.graph.name, onnx_model, x, expected, self.model_files))
 


### PR DESCRIPTION
This PR reproduces a discrepancy between the ONNX and Keras models for handling inputs that are fully masked. This occurs for RNN models that contain both a masking layer, and use a non-zero bias. When one of the input entries is fully zero (i.e. will be fully masked by the Masking layer), the RNN output is non-zero. Turning off the bias or using the default bias reproduces consistent behavior with Keras.

```
(Pdb) up
> /home/user/keras-onnx/tests/test_layers.py(1817)test_masking_bias()
-> self.assertTrue(run_onnx_runtime(onnx_model.graph.name, onnx_model, x, expected, self.model_files))
(Pdb) x
array([[[365.8103 , 107.39152, 701.68   , 615.55023, 468.88876],
        [831.7788 , 680.243  , 890.5216 , 550.38116, 970.3993 ],
        [134.01295, 771.0398 , 594.99915, 315.76196, 753.1429 ]],

       [[  0.     ,   0.     ,   0.     ,   0.     ,   0.     ],
        [  0.     ,   0.     ,   0.     ,   0.     ,   0.     ],
        [  0.     ,   0.     ,   0.     ,   0.     ,   0.     ]]],
      dtype=float32)
(Pdb) down
> /home/user/keras-onnx/tests/test_utils.py(153)run_onnx_runtime()
-> return res
(Pdb) expected
[array([[ 0.7615942,  0.       , -0.7615942,  0.       ,  0.       ,
         0.       ,  0.7615942,  0.       ],
       [ 0.       ,  0.       ,  0.       ,  0.       ,  0.       ,
         0.       ,  0.       ,  0.       ]], dtype=float32)]
(Pdb) actual
[array([[ 0.76159436,  0.        , -0.76159436,  0.        ,  0.        ,
         0.        ,  0.76159436,  0.        ],
       [ 0.2423832 ,  0.26090473,  0.08070117,  0.30603507,  0.13741694,
         0.24133024,  0.513518  ,  0.37147206]], dtype=float32)]
```

This is a problem for architectures using multiple RNN layers with masking. Any suggestions or thoughts are appreciated!