### PR TITLE
Custom Masking value

### DIFF
--- a/keras2onnx/_parser_1x.py
+++ b/keras2onnx/_parser_1x.py
@@ -111,6 +111,9 @@ def on_parsing_keras_layer(graph, node_list, layer, kenode, model, varset, prefi
             mts_var = varset.get_local_variable_or_declare_one(mts_name, infer_variable_type(om_, varset.target_opset))
             operator.add_output_mask(mts_var)
 
+    if hasattr(layer, 'mask_value') and layer.mask_value is not None:
+        operator.mask_value = layer.mask_value
+
     cvt = get_converter(operator.type)
     if cvt is not None and hasattr(cvt, 'shape_infer'):
         operator.shape_infer = cvt.shape_infer

--- a/keras2onnx/common/intop.py
+++ b/keras2onnx/common/intop.py
@@ -26,6 +26,7 @@ class Operator:
         self.input_masks = []
         self.outputs = []
         self.output_masks = []
+        self.mask_value = None
         self.nodelist = None
         self.is_evaluated = None
         self.target_opset = target_opset

--- a/keras2onnx/ke2onnx/main.py
+++ b/keras2onnx/ke2onnx/main.py
@@ -68,9 +68,8 @@ def convert_keras_flatten(scope, operator, container):
 
 
 def _apply_not_equal(oopb, target_opset, operator):
-    mask_value = np.array([operator.mask_value], dtype='float32')
     if target_opset >= 11:
-        equal_out = oopb.add_node('Equal', [operator.inputs[0].full_name, mask_value],
+        equal_out = oopb.add_node('Equal', [operator.inputs[0].full_name, np.array([operator.mask_value], dtype='float32')],
                                   operator.full_name + 'mask')
         not_o = oopb.add_node('Not', equal_out,
                               name=operator.full_name + '_not')
@@ -79,7 +78,7 @@ def _apply_not_equal(oopb, target_opset, operator):
                              "the masking layer result may be incorrect if the model input is in range (0, 1.0).")
         equal_input_0 = oopb.add_node('Cast', [operator.inputs[0].full_name],
                                       operator.full_name + '_input_cast', to=6)
-        equal_out = oopb.add_node('Equal', [equal_input_0, mask_value],
+        equal_out = oopb.add_node('Equal', [equal_input_0, np.array([operator.mask_value], dtype='int32')],
                                   operator.full_name + 'mask')
         not_o = oopb.add_node('Not', equal_out,
                               name=operator.full_name + '_not')

--- a/keras2onnx/ke2onnx/main.py
+++ b/keras2onnx/ke2onnx/main.py
@@ -68,8 +68,9 @@ def convert_keras_flatten(scope, operator, container):
 
 
 def _apply_not_equal(oopb, target_opset, operator):
+    mask_value = np.array([operator.mask_value], dtype='float32')
     if target_opset >= 11:
-        equal_out = oopb.add_node('Equal', [operator.inputs[0].full_name, np.array([0], dtype='float32')],
+        equal_out = oopb.add_node('Equal', [operator.inputs[0].full_name, mask_value],
                                   operator.full_name + 'mask')
         not_o = oopb.add_node('Not', equal_out,
                               name=operator.full_name + '_not')
@@ -78,7 +79,7 @@ def _apply_not_equal(oopb, target_opset, operator):
                              "the masking layer result may be incorrect if the model input is in range (0, 1.0).")
         equal_input_0 = oopb.add_node('Cast', [operator.inputs[0].full_name],
                                       operator.full_name + '_input_cast', to=6)
-        equal_out = oopb.add_node('Equal', [equal_input_0, np.array([0], dtype='int32')],
+        equal_out = oopb.add_node('Equal', [equal_input_0, mask_value],
                                   operator.full_name + 'mask')
         not_o = oopb.add_node('Not', equal_out,
                               name=operator.full_name + '_not')

--- a/keras2onnx/ke2onnx/main.py
+++ b/keras2onnx/ke2onnx/main.py
@@ -68,6 +68,8 @@ def convert_keras_flatten(scope, operator, container):
 
 
 def _apply_not_equal(oopb, target_opset, operator):
+    if operator.mask_value is None:
+        raise ValueError("Masking value was not properly parsed for layer '{}'".format(operator.full_name))
     if target_opset >= 11:
         equal_out = oopb.add_node('Equal', [operator.inputs[0].full_name, np.array([operator.mask_value], dtype='float32')],
                                   operator.full_name + 'mask')

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1789,6 +1789,21 @@ class TestKerasTF2ONNX(unittest.TestCase):
         self.assertTrue(run_onnx_runtime(onnx_model.graph.name, onnx_model, x, expected, self.model_files))
 
     @unittest.skipIf(is_tf2 and is_tf_keras, 'TODO')
+    def test_masking_value(self):
+        timesteps, features = (3, 5)
+        mask_value = 5.
+        model = Sequential([
+            keras.layers.Masking(mask_value=mask_value, input_shape=(timesteps, features)),
+            LSTM(8, return_state=False, return_sequences=False)
+        ])
+
+        onnx_model = keras2onnx.convert_keras(model, model.name)
+        x = np.random.uniform(100, 999, size=(2, 3, 5)).astype(np.float32)
+        x[1, :, :] = mask_value
+        expected = model.predict(x)
+        self.assertTrue(run_onnx_runtime(onnx_model.graph.name, onnx_model, x, expected, self.model_files))
+
+    @unittest.skipIf(is_tf2 and is_tf_keras, 'TODO')
     def test_masking_custom(self):
         class MyPoolingMask(keras.layers.Layer):
             def __init__(self, **kwargs):


### PR DESCRIPTION
This PR uses the actual `mask_value`, instead of assuming that it is `0.0`. This allows custom mask values to be used, as long as they can be represented as a float32 or int32 (e.g. `np.nan` works as expected).

I added `mask_value` to the  `Operator` class to be able to pass that information down. I'm not convinced this is the best form, but it seemed to be the easiest way in the short term.