### PR TITLE
Bidirectional Masking support

### DIFF
--- a/keras2onnx/ke2onnx/bidirectional.py
+++ b/keras2onnx/ke2onnx/bidirectional.py
@@ -159,66 +159,30 @@ def convert_bidirectional(scope, operator, container):
         lstm_input_names.append('')
     oopb = OnnxOperatorBuilder(container, scope)
 
-    if container.target_opset < 9:
-        # need the zero initializer to correct some engine shape inference bug.
-        state_shape = (2, 1, hidden_size)
-        initial_h_name = scope.get_unique_variable_name(operator.full_name + '_initial_h')
-        container.add_initializer(initial_h_name, onnx_proto.TensorProto.FLOAT, state_shape,
-                                  np.zeros(shape=state_shape).flatten())
-        lstm_input_names.append(initial_h_name)
-        initial_c_name = scope.get_unique_variable_name(operator.full_name + '_initial_c')
-        container.add_initializer(initial_c_name, onnx_proto.TensorProto.FLOAT, state_shape,
-                                  np.zeros(shape=state_shape).flatten())
-        lstm_input_names.append(initial_c_name)
-    else:
+    #initial_h defaults to 0
+    lstm_input_names.append('')
+    #initial_c defaults to 0
+    lstm_input_names.append('')
+
+    if container.target_opset >= 9 and not is_static_shape:
         input_shape_tensor = oopb.add_node('Shape',
                                            [operator.input_full_names[0]],
                                            operator.inputs[0].full_name + '_input_shape_tensor')
 
         if container.target_opset >= 10:
-            batch_indices_tensor = oopb.add_node('Slice',
-                                                 [input_shape_tensor,
-                                                  ('_start', oopb.int64, np.array([0], dtype='int64')),
-                                                  ('_end', oopb.int64, np.array([1], dtype='int64')),
-                                                  ('_axes', oopb.int64, np.array([0], dtype='int64'))
-                                                  ],
-                                                 operator.inputs[0].full_name + '_batch_indices_tensor')
 
-            if not is_static_shape:
-                seq_len_tensor = oopb.add_node('Slice',
-                                               [input_shape_tensor,
-                                                ('_start', oopb.int64, np.array([1], dtype='int64')),
-                                                ('_end', oopb.int64, np.array([2], dtype='int64')),
-                                                ('_axes', oopb.int64, np.array([0], dtype='int64'))
-                                                ],
-                                               operator.inputs[0].full_name + '_seq_len_tensor')
+            seq_len_tensor = oopb.add_node('Slice',
+                                           [input_shape_tensor,
+                                            ('_start', oopb.int64, np.array([1], dtype='int64')),
+                                            ('_end', oopb.int64, np.array([2], dtype='int64')),
+                                            ('_axes', oopb.int64, np.array([0], dtype='int64'))
+                                            ],
+                                           operator.inputs[0].full_name + '_seq_len_tensor')
         else:
-            attrs = {'starts': [0], 'ends': [1], 'axes': [0]}
-            batch_indices_tensor = oopb.add_node('Slice',
-                                                 [input_shape_tensor],
-                                                 operator.inputs[0].full_name + '_batch_indices_tensor', **attrs)
-
-            if not is_static_shape:
-                attrs = {'starts': [1], 'ends': [2], 'axes': [0]}
-                seq_len_tensor = oopb.add_node('Slice',
-                                               [input_shape_tensor],
-                                               operator.inputs[0].full_name + '_seq_len_tensor', **attrs)
-
-        batch_size_tensor = oopb.add_node('Concat',
-                                          [('_a', oopb.int64, np.array([2], dtype='int64')),
-                                           batch_indices_tensor,
-                                           ('_b', oopb.int64, np.array([hidden_size], dtype='int64'))
-                                           ],
-                                          operator.inputs[0].full_name + '_state_shape_tensor', axis=0)
-
-        state_constant_shape_h = oopb.add_node('ConstantOfShape',
-                                               [batch_size_tensor],
-                                               operator.inputs[0].full_name + '_state_shape_constant_h')
-        state_constant_shape_c = oopb.add_node('ConstantOfShape',
-                                               [batch_size_tensor],
-                                               operator.inputs[0].full_name + '_state_shape_constant_c')
-        lstm_input_names.append(state_constant_shape_h)
-        lstm_input_names.append(state_constant_shape_c)
+            attrs = {'starts': [1], 'ends': [2], 'axes': [0]}
+            seq_len_tensor = oopb.add_node('Slice',
+                                           [input_shape_tensor],
+                                           operator.inputs[0].full_name + '_seq_len_tensor', **attrs)
 
     # P (optional) : No peep hole in keras.
     lstm_input_names.append('')

--- a/keras2onnx/ke2onnx/bidirectional.py
+++ b/keras2onnx/ke2onnx/bidirectional.py
@@ -159,30 +159,66 @@ def convert_bidirectional(scope, operator, container):
         lstm_input_names.append('')
     oopb = OnnxOperatorBuilder(container, scope)
 
-    #initial_h defaults to 0
-    lstm_input_names.append('')
-    #initial_c defaults to 0
-    lstm_input_names.append('')
-
-    if container.target_opset >= 9 and not is_static_shape:
+    if container.target_opset < 9:
+        # need the zero initializer to correct some engine shape inference bug.
+        state_shape = (2, 1, hidden_size)
+        initial_h_name = scope.get_unique_variable_name(operator.full_name + '_initial_h')
+        container.add_initializer(initial_h_name, onnx_proto.TensorProto.FLOAT, state_shape,
+                                  np.zeros(shape=state_shape).flatten())
+        lstm_input_names.append(initial_h_name)
+        initial_c_name = scope.get_unique_variable_name(operator.full_name + '_initial_c')
+        container.add_initializer(initial_c_name, onnx_proto.TensorProto.FLOAT, state_shape,
+                                  np.zeros(shape=state_shape).flatten())
+        lstm_input_names.append(initial_c_name)
+    else:
         input_shape_tensor = oopb.add_node('Shape',
                                            [operator.input_full_names[0]],
                                            operator.inputs[0].full_name + '_input_shape_tensor')
 
         if container.target_opset >= 10:
+            batch_indices_tensor = oopb.add_node('Slice',
+                                                 [input_shape_tensor,
+                                                  ('_start', oopb.int64, np.array([0], dtype='int64')),
+                                                  ('_end', oopb.int64, np.array([1], dtype='int64')),
+                                                  ('_axes', oopb.int64, np.array([0], dtype='int64'))
+                                                  ],
+                                                 operator.inputs[0].full_name + '_batch_indices_tensor')
 
-            seq_len_tensor = oopb.add_node('Slice',
-                                           [input_shape_tensor,
-                                            ('_start', oopb.int64, np.array([1], dtype='int64')),
-                                            ('_end', oopb.int64, np.array([2], dtype='int64')),
-                                            ('_axes', oopb.int64, np.array([0], dtype='int64'))
-                                            ],
-                                           operator.inputs[0].full_name + '_seq_len_tensor')
+            if not is_static_shape:
+                seq_len_tensor = oopb.add_node('Slice',
+                                               [input_shape_tensor,
+                                                ('_start', oopb.int64, np.array([1], dtype='int64')),
+                                                ('_end', oopb.int64, np.array([2], dtype='int64')),
+                                                ('_axes', oopb.int64, np.array([0], dtype='int64'))
+                                                ],
+                                               operator.inputs[0].full_name + '_seq_len_tensor')
         else:
-            attrs = {'starts': [1], 'ends': [2], 'axes': [0]}
-            seq_len_tensor = oopb.add_node('Slice',
-                                           [input_shape_tensor],
-                                           operator.inputs[0].full_name + '_seq_len_tensor', **attrs)
+            attrs = {'starts': [0], 'ends': [1], 'axes': [0]}
+            batch_indices_tensor = oopb.add_node('Slice',
+                                                 [input_shape_tensor],
+                                                 operator.inputs[0].full_name + '_batch_indices_tensor', **attrs)
+
+            if not is_static_shape:
+                attrs = {'starts': [1], 'ends': [2], 'axes': [0]}
+                seq_len_tensor = oopb.add_node('Slice',
+                                               [input_shape_tensor],
+                                               operator.inputs[0].full_name + '_seq_len_tensor', **attrs)
+
+        batch_size_tensor = oopb.add_node('Concat',
+                                          [('_a', oopb.int64, np.array([2], dtype='int64')),
+                                           batch_indices_tensor,
+                                           ('_b', oopb.int64, np.array([hidden_size], dtype='int64'))
+                                           ],
+                                          operator.inputs[0].full_name + '_state_shape_tensor', axis=0)
+
+        state_constant_shape_h = oopb.add_node('ConstantOfShape',
+                                               [batch_size_tensor],
+                                               operator.inputs[0].full_name + '_state_shape_constant_h')
+        state_constant_shape_c = oopb.add_node('ConstantOfShape',
+                                               [batch_size_tensor],
+                                               operator.inputs[0].full_name + '_state_shape_constant_c')
+        lstm_input_names.append(state_constant_shape_h)
+        lstm_input_names.append(state_constant_shape_c)
 
     # P (optional) : No peep hole in keras.
     lstm_input_names.append('')

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1828,12 +1828,13 @@ class TestKerasTF2ONNX(unittest.TestCase):
 
     @unittest.skipIf(is_tf2 and is_tf_keras, 'TODO')
     def test_masking_bias_bidirectional(self):
-        for rnn_class in [LSTM, GRU, SimpleRNN]:
+        # TODO: Support GRU and SimpleRNN
+        for rnn_class in [LSTM]:
 
             timesteps, features = (3, 5)
             model = Sequential([
                 keras.layers.Masking(mask_value=0., input_shape=(timesteps, features)),
-                Bidirectional(rnn_class(8, return_state=False, return_sequences=False, use_bias=True, name='rnn'))
+                Bidirectional(rnn_class(8, return_state=False, return_sequences=False, use_bias=True), name='bi')
             ])
 
             x = np.random.uniform(100, 999, size=(2, 3, 5)).astype(np.float32)
@@ -1846,9 +1847,10 @@ class TestKerasTF2ONNX(unittest.TestCase):
             self.assertTrue(run_onnx_runtime(onnx_model.graph.name, onnx_model, x, expected, self.model_files))
 
             # Set bias values to random floats
-            rnn_layer = model.get_layer('rnn')
+            rnn_layer = model.get_layer('bi')
             weights = rnn_layer.get_weights()
             weights[2] = np.random.uniform(size=weights[2].shape)
+            weights[5] = weights[2]
             rnn_layer.set_weights(weights)
 
             # Test with random bias

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1826,7 +1826,7 @@ class TestKerasTF2ONNX(unittest.TestCase):
             onnx_model = keras2onnx.convert_keras(model, model.name)
             self.assertTrue(run_onnx_runtime(onnx_model.graph.name, onnx_model, x, expected, self.model_files))
 
-    @unittest.skipIf(is_tf2 and is_tf_keras, 'TODO')
+    @unittest.skipIf((is_tf2 and is_tf_keras) or get_opset_number_from_onnx() < 9, 'TODO')
     def test_masking_bias_bidirectional(self):
         # TODO: Support GRU and SimpleRNN
         for rnn_class in [LSTM]:

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1827,6 +1827,36 @@ class TestKerasTF2ONNX(unittest.TestCase):
             self.assertTrue(run_onnx_runtime(onnx_model.graph.name, onnx_model, x, expected, self.model_files))
 
     @unittest.skipIf(is_tf2 and is_tf_keras, 'TODO')
+    def test_masking_bias_bidirectional(self):
+        for rnn_class in [LSTM, GRU, SimpleRNN]:
+
+            timesteps, features = (3, 5)
+            model = Sequential([
+                keras.layers.Masking(mask_value=0., input_shape=(timesteps, features)),
+                Bidirectional(rnn_class(8, return_state=False, return_sequences=False, use_bias=True, name='rnn'))
+            ])
+
+            x = np.random.uniform(100, 999, size=(2, 3, 5)).astype(np.float32)
+            # Fill one of the entries with all zeros except the first timestep
+            x[1, 1:, :] = 0
+
+            # Test with the default bias
+            expected = model.predict(x)
+            onnx_model = keras2onnx.convert_keras(model, model.name)
+            self.assertTrue(run_onnx_runtime(onnx_model.graph.name, onnx_model, x, expected, self.model_files))
+
+            # Set bias values to random floats
+            rnn_layer = model.get_layer('rnn')
+            weights = rnn_layer.get_weights()
+            weights[2] = np.random.uniform(size=weights[2].shape)
+            rnn_layer.set_weights(weights)
+
+            # Test with random bias
+            expected = model.predict(x)
+            onnx_model = keras2onnx.convert_keras(model, model.name)
+            self.assertTrue(run_onnx_runtime(onnx_model.graph.name, onnx_model, x, expected, self.model_files))
+
+    @unittest.skipIf(is_tf2 and is_tf_keras, 'TODO')
     def test_masking_value(self):
         timesteps, features = (3, 5)
         mask_value = 5.


### PR DESCRIPTION
This PR fixes the case of a Bidirectional LSTM when used in conjunction with a Masking layer. This follows the same solution as #386. The new graph connects the masking output to a section that computes the sequence lengths, which provides proper masking for padded input. Since the GRU and SimpleRNN layers are not yet supported for the bidirectional case, this PR does not include those cases.

![temp_sequential onnx(1)](https://user-images.githubusercontent.com/4521567/75618546-fb91f200-5b3d-11ea-944d-6d5f67953e9d.png)
