### PR TITLE
Refactor RNN parameter extracting

### DIFF
--- a/keras2onnx/ke2onnx/gru.py
+++ b/keras2onnx/ke2onnx/gru.py
@@ -16,7 +16,11 @@ def extract_params(op):
     params = op.get_weights()
     W = params[0].T
     R = params[1].T
-    B = params[2]
+
+    B = None
+    if op.use_bias:
+        B = params[2]
+
     return W, R, B
 
 
@@ -47,7 +51,7 @@ def convert_keras_gru(scope, operator, container):
                               [1, 3 * hidden_size, hidden_size], R.flatten())
     gru_input_names.append(tensor_r_name)
 
-    if op.use_bias and len(B) > 0:
+    if B is not None and len(B) > 0:
         tensor_b_name = scope.get_unique_variable_name('tensor_b')
         if B.size == 3 * hidden_size:
             B = np.concatenate([B, np.zeros(3 * hidden_size)])

--- a/keras2onnx/ke2onnx/lstm.py
+++ b/keras2onnx/ke2onnx/lstm.py
@@ -13,7 +13,6 @@ from .common import extract_recurrent_activation
 from . import simplernn
 
 
-
 def convert_ifco_to_iofc(tensor_ifco):
     """Returns a tensor in input (i), output (o), forget (f), cell (c) ordering. The
     Keras ordering is ifco, while the ONNX ordering is iofc.


### PR DESCRIPTION
This PR is a step towards supporting SimpleRNN and GRU in the Bidirectional layer, by moving toward a consistent API across the RNN layers. It refactors the RNN code to increase sharing, and re-uses that in the Bidirectional LSTM case. No functional changes are made -- this PR is purely a refactor.

@wenbingl, can you review these changes?