### PR TITLE
Parametrizing RNN tests

### DIFF
--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -2034,7 +2034,7 @@ def test_masking_value(runner, rnn_class):
     ])
 
     onnx_model = keras2onnx.convert_keras(model, model.name)
-    x = np.random.uniform(0, 1, size=(2, 3, 5)).astype(np.float32)
+    x = np.random.uniform(100, 999, size=(2, 3, 5)).astype(np.float32)
     x[1, :, :] = mask_value
     expected = model.predict(x)
     assert runner(onnx_model.graph.name, onnx_model, x, expected)


### PR DESCRIPTION
This PR parametrizes the RNN tests to run over the RNN classes (SimpleRNN, GRU, and LSTM). This simplifies the existing test functions, and provides the ability to filter on a specific class of interest. For example, to run all of the GRU tests, you can filter on GRU:
```
$ pytest tests -k GRU -vv
===================================== test session starts =====================================
...
collected 163 items / 152 deselected / 1 skipped / 10 selected                                

tests/test_layers.py::test_GRU PASSED                                                   [  9%]
tests/test_layers.py::test_Bidirectional[GRU-True] PASSED                               [ 18%]
tests/test_layers.py::test_Bidirectional[GRU-False] PASSED                              [ 27%]
tests/test_layers.py::test_Bidirectional_with_bias[GRU] PASSED                          [ 36%]
tests/test_layers.py::test_Bidirectional_with_initial_states[GRU] PASSED                [ 45%]
tests/test_layers.py::test_Bidirectional_seqlen_none[GRU] PASSED                        [ 54%]
tests/test_layers.py::test_rnn_state_passing[GRU] SKIPPED                               [ 63%]
tests/test_layers.py::test_masking[GRU] PASSED                                          [ 72%]
tests/test_layers.py::test_masking_bias[GRU] PASSED                                     [ 81%]
tests/test_layers.py::test_masking_bias_bidirectional[GRU] PASSED                       [ 90%]
tests/test_layers.py::test_masking_value[GRU] PASSED                                    [100%]

====================================== warnings summary =======================================
...
================== 10 passed, 2 skipped, 152 deselected, 1 warning in 7.68s ===================
```