### PR TITLE
Handle time_major in lstm and remove reshape from embedding

### DIFF
--- a/keras2onnx/ke2onnx/embedding.py
+++ b/keras2onnx/ke2onnx/embedding.py
@@ -29,13 +29,8 @@ def convert_keras_embed(scope, operator, container):
             container.add_node('Not', equal_out, operator.output_masks[0].full_name,
                                name=operator.full_name + 'mask_not')
 
-    # Reshape the indexes we want to embed to 1-D tensor. Otherwise, Gather's output may get wrong shape, which is the
-    # same as our CoreML Embedding converter.
-    reshaped_input_name = scope.get_unique_variable_name('embedding_reshaped')
-    apply_reshape(scope, operator.inputs[0].full_name, reshaped_input_name, container, desired_shape=[0, -1])
-
     cast_name = scope.get_unique_variable_name('casted')
-    apply_cast(scope, reshaped_input_name, cast_name, container, to=onnx_proto.TensorProto.INT32)
+    apply_cast(scope, operator.inputs[0].full_name, cast_name, container, to=onnx_proto.TensorProto.INT32)
 
     # Prepare the weight matrix (i.e., the vectors of all input indices) as an initializer so that the following main
     # operator can access it.

--- a/keras2onnx/ke2onnx/lstm.py
+++ b/keras2onnx/ke2onnx/lstm.py
@@ -14,6 +14,7 @@ from ..common.onnx_ops import (
     apply_slice,
     apply_split,
     apply_squeeze,
+    apply_unsqueeze,
     apply_transpose,
     OnnxOperatorBuilder
 )
@@ -142,12 +143,9 @@ def build_initial_states(scope, operator, container, bidirectional=False):
         apply_concat(scope, [forward_h, backward_h], initial_c, container)
 
     else:
-        hidden_size = operator.raw_operator.units
-        desired_shape = [1, -1, hidden_size]
-
-        # Add a reshape after initial_c, 2d -> 3d
+        # Unsqueeze dim 0 to represent num_directions
         input_c = operator.inputs[2].full_name
-        apply_reshape(scope, input_c, initial_c, container, desired_shape=desired_shape)
+        apply_unsqueeze(scope, input_c, initial_c, container, axes=[0])
 
     return initial_h, initial_c
 
@@ -207,33 +205,21 @@ def build_output(scope, operator, container, output_names, bidirectional=False):
 
     # Create output-adjusting operators
     if output_seq:
-        transposed_y = _name('y_transposed')
-        perm = [1, 0, 2] if container.target_opset <= 5 else [2, 0, 1, 3]
-        apply_transpose(scope, lstm_y, transposed_y, container, perm=perm)
+        lstm_out = lstm_y
+        if not op.time_major:
+            # Onnx LSTM produces time major output. Add a transpose operator to
+            # make it batch_major, if the keras op was not time_major.
+            # This transforms [ S, 1, B, I] -> [ B, 1, S, I ] where B is
+            # batch_size and S is seq_len.
+            perm = [2, 1, 0, 3]
+            lstm_out = _name('y_transposed')
+            apply_transpose(scope, lstm_y, lstm_out, container, perm=perm)
 
-        if is_static_shape:
-            apply_reshape(scope, transposed_y, output_name, container,
-                          desired_shape=[-1, seq_length, hidden_size])
-        else:
-            input_name = operator.inputs[0].full_name
-            input_shape_tensor = oopb.add_node('Shape', [input_name],
-                                               input_name + '_shape_tensor')
-
-            seq_dim = _name('seq_dim')
-            apply_slice(scope, input_shape_tensor, seq_dim, container, [1], [2], axes=[0])
-
-            shape_tensor = oopb.add_node('Concat',
-                                         [('_a', oopb.int64, np.array([-1], dtype='int64')),
-                                          seq_dim,
-                                          ('_b', oopb.int64, np.array([hidden_size], dtype='int64'))
-                                          ],
-                                         input_name + '_output_seq_shape', axis=0)
-            shape_tensor_output = oopb.add_node('Reshape',
-                                                [transposed_y, shape_tensor],
-                                                input_name + '_output_seq_shape_1')
-            apply_identity(scope, shape_tensor_output, output_name, container)
+        # Squeeze the num_direction dim as we know its size is 1 for
+        # lstm(forward/reverse).
+        apply_squeeze(scope, lstm_out, output_name, container, axes=[1])
     else:
-        apply_reshape(scope, lstm_h, output_name, container, desired_shape=[-1, hidden_size])
+        apply_squeeze(scope, lstm_h, output_name, container, axes=[0])
 
 
 def build_output_states(scope, operator, container, output_names, bidirectional=False):
@@ -291,11 +277,21 @@ def convert_keras_lstm(scope, operator, container, bidirectional=False):
 
     if bidirectional:
         output_seq = op.forward_layer.return_sequences
+        time_major = op.forward_layer.time_major
     else:
         output_seq = op.return_sequences
+        time_major = op.time_major
 
     # Inputs
-    lstm_x = _name('X')
+    lstm_x = operator.inputs[0].full_name
+    if not time_major:
+        # If the keras op was not time_major, we add a transpose op to make the
+        # input time_major as ONNX lstm expects time_major input.
+        # Transform [ B, S, I ] -> [ S, B, I] where B is batch_size and S is
+        # seq_len.
+        lstm_x = _name('X')
+        apply_transpose(scope, operator.inputs[0].full_name, lstm_x, container, perm=[1, 0, 2])
+
     tensor_w, tensor_r, tensor_b = build_parameters(scope, operator, container, bidirectional)
     sequence_lengths = simplernn.build_sequence_lengths(scope, operator, container)
     initial_h, initial_c = build_initial_states(scope, operator, container, bidirectional)
@@ -316,10 +312,6 @@ def convert_keras_lstm(scope, operator, container, bidirectional=False):
 
     # Outputs
     output_names = [_name('Y'), _name('Y_h'), _name('Y_c')]
-
-    # Reshape Keras input format into ONNX input format
-    input_name = operator.inputs[0].full_name
-    apply_transpose(scope, input_name, lstm_x, container, perm=[1, 0, 2])
 
     oopb = OnnxOperatorBuilder(container, scope)
     oopb.apply_op_with_output('apply_lstm',

--- a/keras2onnx/ke2onnx/simplernn.py
+++ b/keras2onnx/ke2onnx/simplernn.py
@@ -15,6 +15,7 @@ from ..common.onnx_ops import (
     apply_split,
     apply_squeeze,
     apply_transpose,
+    apply_unsqueeze,
     OnnxOperatorBuilder,
 )
 
@@ -197,13 +198,9 @@ def build_initial_states(scope, operator, container, bidirectional=False):
         apply_concat(scope, [forward_h, backward_h], initial_h, container)
 
     else:
-        hidden_size = operator.raw_operator.units
-        desired_shape = [1, -1, hidden_size]
-
-        # Add a reshape after initial_h, 2d -> 3d
+        # Unsqueeze dim 0 to represent num_directions
         input_h = operator.inputs[1].full_name
-        apply_reshape(scope, input_h, initial_h, container, desired_shape=desired_shape)
-
+        apply_unsqueeze(scope, input_h, initial_h, container, axes=[0])
     return initial_h
 
 

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1545,6 +1545,30 @@ def test_LSTM(runner):
             expected = model.predict(data)
             assert runner(onnx_model.graph.name, onnx_model, data, expected)
 
+def test_LSTM_time_major_return_seq_true(runner):
+    inputs1 = keras.Input(shape=(3, 5))
+    data = np.random.rand(1, 3, 5).astype(np.float32)
+    # Transpose input to be time major
+    input_transposed = tf.transpose(inputs1, perm=[1,0,2])
+    lstm1, state_h, state_c = LSTM(units=2, time_major=True, return_state=True,
+                                   return_sequences=True)(input_transposed)
+    lstm1_trans = tf.transpose(lstm1, perm=[1,0,2])
+    model = keras.Model(inputs=inputs1, outputs=[lstm1_trans, state_h, state_c])
+    onnx_model = keras2onnx.convert_keras(model, model.name)
+    expected = model.predict(data)
+    assert runner(onnx_model.graph.name, onnx_model, data, expected)
+
+def test_LSTM_time_major_return_seq_false(runner):
+    inputs1 = keras.Input(shape=(3, 5))
+    data = np.random.rand(1, 3, 5).astype(np.float32)
+    # Transpose input to be time major
+    input_transposed = tf.transpose(inputs1, perm=[1,0,2])
+    lstm1, state_h, state_c = LSTM(units=2, time_major=True, return_state=True,
+                                   return_sequences=False)(input_transposed)
+    model = keras.Model(inputs=inputs1, outputs=[lstm1, state_h, state_c])
+    onnx_model = keras2onnx.convert_keras(model, model.name)
+    expected = model.predict(data)
+    assert runner(onnx_model.graph.name, onnx_model, data, expected)
 
 def test_LSTM_with_bias(runner):
     inputs1 = keras.Input(shape=(1, 1))


### PR DESCRIPTION
This commit makes the following changes:
1. Embedding was unnecessarily reshaping input to a rank2 tensor. This
   is not required and causes model to diverge from what its actually
   supposed to do.
2. Lstm was not considering time_major param. No transpose of input and
   output is required if the input is already time major, i.e of shape
   [ seq_len, batch_size, input_size]
3. Simplify the handling of case when return sequences is set to true.
4. Use squeeze and unsqueeze instead of reshape for dim representing
direction of lstm for simplicity.