### PR TITLE
Handle time_major in lstm and remove reshape from embedding

### DIFF
--- a/keras2onnx/ke2onnx/embedding.py
+++ b/keras2onnx/ke2onnx/embedding.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 ###############################################################################
-from ..common.onnx_ops import apply_reshape, apply_cast, OnnxOperatorBuilder
+from ..common.onnx_ops import apply_cast, OnnxOperatorBuilder
 from ..proto import onnx_proto
 
 import numpy as np
@@ -29,13 +29,8 @@ def convert_keras_embed(scope, operator, container):
             container.add_node('Not', equal_out, operator.output_masks[0].full_name,
                                name=operator.full_name + 'mask_not')
 
-    # Reshape the indexes we want to embed to 1-D tensor. Otherwise, Gather's output may get wrong shape, which is the
-    # same as our CoreML Embedding converter.
-    reshaped_input_name = scope.get_unique_variable_name('embedding_reshaped')
-    apply_reshape(scope, operator.inputs[0].full_name, reshaped_input_name, container, desired_shape=[0, -1])
-
     cast_name = scope.get_unique_variable_name('casted')
-    apply_cast(scope, reshaped_input_name, cast_name, container, to=onnx_proto.TensorProto.INT32)
+    apply_cast(scope, operator.inputs[0].full_name, cast_name, container, to=onnx_proto.TensorProto.INT32)
 
     # Prepare the weight matrix (i.e., the vectors of all input indices) as an initializer so that the following main
     # operator can access it.

--- a/keras2onnx/ke2onnx/simplernn.py
+++ b/keras2onnx/ke2onnx/simplernn.py
@@ -15,6 +15,7 @@ from ..common.onnx_ops import (
     apply_split,
     apply_squeeze,
     apply_transpose,
+    apply_unsqueeze,
     OnnxOperatorBuilder,
 )
 
@@ -197,13 +198,9 @@ def build_initial_states(scope, operator, container, bidirectional=False):
         apply_concat(scope, [forward_h, backward_h], initial_h, container)
 
     else:
-        hidden_size = operator.raw_operator.units
-        desired_shape = [1, -1, hidden_size]
-
-        # Add a reshape after initial_h, 2d -> 3d
+        # Unsqueeze dim 0 to represent num_directions
         input_h = operator.inputs[1].full_name
-        apply_reshape(scope, input_h, initial_h, container, desired_shape=desired_shape)
-
+        apply_unsqueeze(scope, input_h, initial_h, container, axes=[0])
     return initial_h
 
 

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1545,6 +1545,34 @@ def test_LSTM(runner):
             expected = model.predict(data)
             assert runner(onnx_model.graph.name, onnx_model, data, expected)
 
+@pytest.mark.skipif((is_tensorflow_older_than('1.14.0') or (not is_tf_keras)),
+                    reason="keras LSTM does not have time_major attribute")
+def test_LSTM_time_major_return_seq_true(runner):
+    inputs1 = keras.Input(shape=(3, 5))
+    data = np.random.rand(1, 3, 5).astype(np.float32)
+    # Transpose input to be time major
+    input_transposed = tf.transpose(inputs1, perm=[1,0,2])
+    lstm1, state_h, state_c = LSTM(units=2, time_major=True, return_state=True,
+                                   return_sequences=True)(input_transposed)
+    lstm1_trans = tf.transpose(lstm1, perm=[1,0,2])
+    model = keras.Model(inputs=inputs1, outputs=[lstm1_trans, state_h, state_c])
+    onnx_model = keras2onnx.convert_keras(model, model.name)
+    expected = model.predict(data)
+    assert runner(onnx_model.graph.name, onnx_model, data, expected)
+
+@pytest.mark.skipif((is_tensorflow_older_than('1.14.0') or (not is_tf_keras)) ,
+                    reason="keras LSTM does not have time_major attribute")
+def test_LSTM_time_major_return_seq_false(runner):
+    inputs1 = keras.Input(shape=(3, 5))
+    data = np.random.rand(1, 3, 5).astype(np.float32)
+    # Transpose input to be time major
+    input_transposed = tf.transpose(inputs1, perm=[1,0,2])
+    lstm1, state_h, state_c = LSTM(units=2, time_major=True, return_state=True,
+                                   return_sequences=False)(input_transposed)
+    model = keras.Model(inputs=inputs1, outputs=[lstm1, state_h, state_c])
+    onnx_model = keras2onnx.convert_keras(model, model.name)
+    expected = model.predict(data)
+    assert runner(onnx_model.graph.name, onnx_model, data, expected)
 
 def test_LSTM_with_bias(runner):
     inputs1 = keras.Input(shape=(1, 1))


### PR DESCRIPTION
This commit makes the following changes:
1. Embedding was unnecessarily reshaping input to a rank2 tensor. This
   is not required and causes model to diverge from what its actually
   supposed to do.
2. Lstm was not considering time_major param. No transpose of input and
   output is required if the input is already time major, i.e of shape
   [ seq_len, batch_size, input_size]
3. Simplify the handling of case when return sequences is set to true.
4. Use squeeze and unsqueeze instead of reshape for dim representing
direction of lstm for simplicity.