### PR TITLE
Add support for tf.nn.depth_to_space lambda

### DIFF
--- a/keras2onnx/_builtin.py
+++ b/keras2onnx/_builtin.py
@@ -375,8 +375,6 @@ def _calc_explicit_padding(input_size, output_shape, output_padding, kernel_shap
 
 @converter_func(TYPES.DepthToSpace)
 def convert_tf_depth_to_space(scope, operator, container):
-    if operator.target_opset < 11:
-        raise ValueError("DepthToSpace op is not supported for opset < 11")
     node = operator.raw_operator
     block_size = node.get_attr('block_size')
     oopb = OnnxOperatorBuilder(container, scope)
@@ -400,7 +398,8 @@ def convert_tf_depth_to_space(scope, operator, container):
                                   operator.output_full_names,
                                   name=operator.full_name,
                                   blocksize=block_size,
-                                  mode="DCR")
+                                  mode="DCR",
+                                  op_version=11)
 
 
 @converter_func(TYPES.DepthwiseConv2dNative)

--- a/keras2onnx/_builtin.py
+++ b/keras2onnx/_builtin.py
@@ -373,6 +373,21 @@ def _calc_explicit_padding(input_size, output_shape, output_padding, kernel_shap
     return pads
 
 
+@converter_func(TYPES.DepthToSpace)
+def convert_tf_depth_to_space(scope, operator, container):
+    if operator.target_opset < 11:
+        raise ValueError("DepthToSpace op is not supported for opset < 11")
+    node = operator.raw_operator
+    oopb = OnnxOperatorBuilder(container, scope)
+    mode = "CRD" if _is_nhwc(node) else "DCR"
+    oopb.add_node_with_output("DepthToSpace",
+                              operator.input_full_names,
+                              operator.output_full_names,
+                              name=operator.full_name,
+                              blocksize=node.get_attr('block_size'),
+                              mode=mode)
+
+
 @converter_func(TYPES.DepthwiseConv2dNative)
 def convert_tf_depthwise_conv2d(scope, operator, container):
     node = operator.raw_operator

--- a/keras2onnx/_consts.py
+++ b/keras2onnx/_consts.py
@@ -27,6 +27,7 @@ class TYPES:
     Conv1D = 'Conv1D'
     Conv2D = 'Conv2D'
     Cumsum = 'Cumsum'
+    DepthToSpace = 'DepthToSpace'
     DepthwiseConv2dNative = 'DepthwiseConv2dNative'
     Div = 'Div'
     Einsum = 'Einsum'

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -92,6 +92,8 @@ def test_keras_lambda(runner):
 
 @pytest.mark.skipif(is_tensorflow_older_than('1.12.0'),
                     reason="tf.nn.depth_to_space not supported.")
+@pytest.mark.skipif(get_maximum_opset_supported() < 11,
+                    reason="DepthToSpace is not supported before opset 11.")
 @pytest.mark.parametrize("data_format", ["NCHW", "NHWC"])
 def test_keras_lambda_depth_to_space(runner, data_format):
     input_shape = [4, 6, 8]

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -90,6 +90,8 @@ def test_keras_lambda(runner):
     assert runner('onnx_lambda', onnx_model, data, expected)
 
 
+@pytest.mark.skipif(is_tensorflow_older_than('1.12.0'),
+                    reason="tf.nn.depth_to_space not supported.")
 @pytest.mark.parametrize("data_format", ["NCHW", "NHWC"])
 def test_keras_lambda_depth_to_space(runner, data_format):
     input_shape = [4, 6, 8]

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -96,6 +96,8 @@ def test_keras_lambda(runner):
                     reason="DepthToSpace is not supported before opset 11.")
 @pytest.mark.parametrize("data_format", ["NCHW", "NHWC"])
 def test_keras_lambda_depth_to_space(runner, data_format):
+    if data_format == "NCHW" and is_tensorflow_older_than("2.1.0"):
+        pytest.skip("tf.nn.depth_to_space with NCHW not supported for Tensorflow older than 2.1.0")
     input_shape = [4, 6, 8]
     model = Sequential()
     model.add(Lambda(

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -95,10 +95,10 @@ def test_keras_lambda(runner):
 @pytest.mark.skipif(get_maximum_opset_supported() < 11,
                     reason="DepthToSpace is not supported before opset 11.")
 @pytest.mark.parametrize("data_format", ["NCHW", "NHWC"])
-def test_keras_lambda_depth_to_space(runner, data_format):
+@pytest.mark.parametrize("input_shape", [(4, 6, 8), (None, None, 8)])
+def test_keras_lambda_depth_to_space(runner, data_format, input_shape):
     if data_format == "NCHW" and is_tensorflow_older_than("2.1.0"):
         pytest.skip("tf.nn.depth_to_space with NCHW not supported for Tensorflow older than 2.1.0")
-    input_shape = [4, 6, 8]
     model = Sequential()
     model.add(Lambda(
         lambda x: tf.nn.depth_to_space(x, block_size=2, data_format=data_format),
@@ -106,7 +106,7 @@ def test_keras_lambda_depth_to_space(runner, data_format):
     ))
 
     onnx_model = keras2onnx.convert_keras(model, 'test_keras_lambda_depth_to_space')
-    data = np.random.rand(3, *input_shape).astype(np.float32)
+    data = np.random.rand(3, 4, 6, 8).astype(np.float32)  # batch dimension + 'input_shape'
     expected = model.predict(data)
     assert runner('tf_depth_to_space', onnx_model, data, expected)
 

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -90,6 +90,21 @@ def test_keras_lambda(runner):
     assert runner('onnx_lambda', onnx_model, data, expected)
 
 
+@pytest.mark.parametrize("data_format", ["NCHW", "NHWC"])
+def test_keras_lambda_depth_to_space(runner, data_format):
+    input_shape = [4, 6, 8]
+    model = Sequential()
+    model.add(Lambda(
+        lambda x: tf.nn.depth_to_space(x, block_size=2, data_format=data_format),
+        input_shape=input_shape
+    ))
+
+    onnx_model = keras2onnx.convert_keras(model, 'test_keras_lambda_depth_to_space')
+    data = np.random.rand(3, *input_shape).astype(np.float32)
+    expected = model.predict(data)
+    assert runner('tf_depth_to_space', onnx_model, data, expected)
+
+
 def test_tf_addn(runner):
     input1 = Input(shape=(5, 3, 4), dtype=tf.float32)
     input2 = Input(shape=(5, 3, 4), dtype=tf.float32)


### PR DESCRIPTION
Added support for [tf.nn.depth_to_space](https://www.tensorflow.org/api_docs/python/tf/nn/depth_to_space) as a Keras lambda, mapped to the ONNX [DepthToSpace](https://github.com/onnx/onnx/blob/master/docs/Operators.md#DepthToSpace) operator.

The two added test-cases visualised with Netron:

Channels first (NCHW), channel dimension reduced from 4 to 4/(2*2) = 1, width & height dimension increased by a factor 2:
![temp_NCHW onnx](https://user-images.githubusercontent.com/1162108/82153382-66161c80-9867-11ea-9bc8-d6fedda9e579.png)

Channels last (NHWC), channel dimension reduced from 8 to 8/(2*2) = 2, width & height dimension increased by a factor 2:
![temp_NHWC onnx](https://user-images.githubusercontent.com/1162108/82153381-64e4ef80-9867-11ea-942d-73efae23a89e.png)

Although the visualisations look correct as far as I can see, the NHWC test-case fails with the following error in the ORT:
```
onnxruntime.capi.onnxruntime_pybind11_state.Fail:
[ONNXRuntimeError] : 1 : FAIL : Node:lambda/DepthToSpace Output:lambda
[ShapeInferenceError] Can't merge shape info.
Both source and target dimension have values but they differ.
Source=1 Target=8 Dimension=1
```
This is my first contribution to keras-onnx (and first ONNX contribution in general), so please review carefully. And I'm also asking for help w.r.t. the second test-case. Or is that a bug in ORT?