### PR TITLE
Add time_major handling for bidirectional lstms

### DIFF
--- a/keras2onnx/ke2onnx/gru.py
+++ b/keras2onnx/ke2onnx/gru.py
@@ -126,8 +126,13 @@ def convert_keras_gru(scope, operator, container, bidirectional=False):
         output_seq = op.return_sequences
         reset_after = op.reset_after
 
+    time_major = simplernn.is_time_major(op, bidirectional)
+
     # Inputs
-    gru_x = _name('X')
+    gru_x = operator.inputs[0].full_name
+    if not time_major:
+        gru_x = _name('X')
+        apply_transpose(scope, operator.inputs[0].full_name, gru_x, container, perm=[1, 0, 2])
     tensor_w, tensor_r, tensor_b = build_parameters(scope, operator, container, bidirectional)
     sequence_lengths = simplernn.build_sequence_lengths(scope, operator, container)
     initial_h = simplernn.build_initial_states(scope, operator, container, bidirectional)
@@ -146,10 +151,6 @@ def convert_keras_gru(scope, operator, container, bidirectional=False):
 
     # Outputs
     output_names = [_name('Y'), _name('Y_h')]
-
-    # Transpose input values
-    input_name = operator.inputs[0].full_name
-    apply_transpose(scope, input_name, gru_x, container, perm=[1, 0, 2])
 
     oopb = OnnxOperatorBuilder(container, scope)
     oopb.apply_op_with_output('apply_gru',

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1833,6 +1833,30 @@ def test_bidirectional_with_bias(runner, rnn_class):
     onnx_model = keras2onnx.convert_keras(model, model.name)
     assert runner(onnx_model.graph.name, onnx_model, x, expected)
 
+@pytest.mark.skipif((is_tensorflow_older_than('2.3.0') or (not is_tf_keras)),
+                     reason=("keras LSTM does not have time_major attribute. There was a bug in tf.keras bidirectional lstm with time_major true which will be fixed in tf-2.3, See - https://github.com/tensorflow/tensorflow/issues/39635"))
+@pytest.mark.parametrize("rnn_class", RNN_CLASSES)
+def test_bidirectional_time_major_true(runner, rnn_class):
+    feature_dim = 1
+    seq_len = 3
+    x = np.ones((1, seq_len, feature_dim), dtype=np.float32)
+
+    for ret_seq in [True, False]:
+        for merge_mode in ['concat', None]:
+            K.clear_session()
+            input = keras.Input(shape=(seq_len, feature_dim))
+            # Transpose input to be time major
+            input_transposed = tf.transpose(input, perm=[1,0,2])
+            output = Bidirectional(rnn_class(1, return_sequences=ret_seq,
+                                             time_major=True),
+                                   name='bi', merge_mode=merge_mode)(input_transposed)
+            if ret_seq and merge_mode == 'concat':
+                output = tf.transpose(output, perm=[1,0,2])
+            model = keras.Model(inputs=input, outputs=output)
+
+            expected = model.predict(x)
+            onnx_model = keras2onnx.convert_keras(model, model.name)
+            assert runner(onnx_model.graph.name, onnx_model, x, expected)
 
 @pytest.mark.parametrize("rnn_class", RNN_CLASSES)
 def test_bidirectional_with_initial_states(runner, rnn_class):


### PR DESCRIPTION
**Description**
```
1. Adds time major handling for bidirectional for all rnns.
2. Reverse order of squeeze and transpose in lstm conversion when return seq_true:
   This makes the onnx model slightly more efficent when the model
   has a stack of lstms that are batch_major.
   By doing squeeze first and transpose later, we get two consucutive transposes
   that get eliminated by the optimizer hereby making model more efficient.
```
**Changes to be committed**
```
	modified:   keras2onnx/ke2onnx/gru.py
	modified:   keras2onnx/ke2onnx/lstm.py
	modified:   keras2onnx/ke2onnx/simplernn.py
	modified:   test_layers.py
```