### PR TITLE
Add both tf.nn.X and tf.compat.v1.nn.X to activation_map

### DIFF
--- a/keras2onnx/ke2onnx/activation.py
+++ b/keras2onnx/ke2onnx/activation.py
@@ -34,7 +34,16 @@ activation_map = {activation_get('sigmoid'): apply_sigmoid,
                   tf.nn.relu: apply_relu,
                   tf.nn.relu6: apply_relu_6,
                   tf.nn.elu: apply_elu,
-                  tf.nn.tanh: apply_tanh}
+                  tf.nn.selu: apply_selu,
+                  tf.nn.tanh: apply_tanh,
+                  'sigmoid': apply_sigmoid,
+                  'softmax': apply_softmax,
+                  'linear': apply_identity,
+                  'relu': apply_relu,
+                  'elu': apply_elu,
+                  'selu': apply_selu,
+                  'tanh': apply_tanh,
+                  'hard_sigmoid': apply_hard_sigmoid}
 
 
 def convert_keras_activation(scope, operator, container):

--- a/keras2onnx/ke2onnx/common.py
+++ b/keras2onnx/ke2onnx/common.py
@@ -21,7 +21,9 @@ def get_permutation_config(n_dims):
 
 def activation_process(scope, operator, container, biased_tensor_name):
     # Create an activation function node and apply activation function to the intermediate tensor
-    apply_activation_function = activation_map[operator.raw_operator.activation]
+    apply_activation_function = \
+        activation_map[operator.raw_operator.activation] if operator.raw_operator.activation in activation_map \
+        else activation_map[operator.raw_operator.activation.__name__]
     if operator.raw_operator.activation in [activation_get('softmax'), keras.activations.softmax]:
         apply_softmax(scope, biased_tensor_name, operator.outputs[0].full_name, container, axis=-1)
     elif operator.raw_operator.activation in [tf.nn.relu6]:

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1374,7 +1374,7 @@ def test_Softmax(advanced_activation_runner):
 
 
 def test_tf_nn_activation(runner):
-    for activation in ['relu', tf.nn.relu, tf.nn.relu6]:
+    for activation in [tf.nn.relu, 'relu', tf.nn.relu6, tf.nn.softmax]:
         model = keras.Sequential([
             Dense(64, activation=activation, input_shape=[10]),
             Dense(64, activation=activation),


### PR DESCRIPTION
The [issue](https://github.com/onnx/keras-onnx/issues/511) cannot convert softmax activation because `operator.raw_operator.activation` is a function that is not the same as `tf.nn.softmax` or `keras.activations.get('softmax')`. We need import `tf` from `keras2onnx.proto.tfcompat`