### PR TITLE
Pin keras==2.3.1 for tensorflow 1.x in nightly build

### DIFF
--- a/.azure-pipelines/linux-CI-keras-applications-nightly.yml
+++ b/.azure-pipelines/linux-CI-keras-applications-nightly.yml
@@ -40,7 +40,7 @@ jobs:
       Python37:
         python.version: '3.7.3'
         ONNX_PATH: onnx==1.6.0
-        INSTALL_KERAS: pip install keras
+        INSTALL_KERAS: pip install keras==2.3.1
         UNINSTALL_KERAS:
         INSTALL_TENSORFLOW: pip install tensorflow==1.15.0
         INSTALL_ORT: pip install -i https://test.pypi.org/simple/ ort-nightly
@@ -51,7 +51,7 @@ jobs:
       Python37-official-ort:
         python.version: '3.7.3'
         ONNX_PATH: onnx==1.6.0
-        INSTALL_KERAS: pip install keras
+        INSTALL_KERAS: pip install keras==2.3.1
         UNINSTALL_KERAS:
         INSTALL_TENSORFLOW: pip install tensorflow==1.15.0
         INSTALL_ORT: pip install onnxruntime==1.3.0

--- a/.azure-pipelines/linux-conda-CI.yml
+++ b/.azure-pipelines/linux-conda-CI.yml
@@ -32,7 +32,7 @@ jobs:
       Python37-tf200:
         python.version: '3.7'
         ONNX_PATH: onnx==1.6.0
-        KERAS: keras
+        KERAS: keras==2.3.1
         TENSORFLOW_PATH: tensorflow==2.0.0
         INSTALL_ORT:
 

--- a/.azure-pipelines/win32-CI-keras-applications-nightly.yml
+++ b/.azure-pipelines/win32-CI-keras-applications-nightly.yml
@@ -40,7 +40,7 @@ jobs:
       Python37:
         python.version: '3.7'
         ONNX_PATH: onnx==1.6.0
-        INSTALL_KERAS: pip install keras
+        INSTALL_KERAS: pip install keras==2.3.1
         UNINSTALL_KERAS:
         INSTALL_TENSORFLOW: pip install tensorflow==1.14.0
         INSTALL_ORT: pip install -i https://test.pypi.org/simple/ ort-nightly
@@ -51,7 +51,7 @@ jobs:
       Python37-official-ort:
         python.version: '3.7'
         ONNX_PATH: onnx==1.6.0
-        INSTALL_KERAS: pip install keras
+        INSTALL_KERAS: pip install keras==2.3.1
         UNINSTALL_KERAS:
         INSTALL_TENSORFLOW: pip install tensorflow==1.14.0
         INSTALL_ORT: pip install onnxruntime==1.1.1

--- a/.azure-pipelines/win32-conda-CI.yml
+++ b/.azure-pipelines/win32-conda-CI.yml
@@ -32,7 +32,7 @@ jobs:
       Python37-tf200:
         python.version: '3.7'
         ONNX_PATH: onnx==1.7.0
-        KERAS: keras
+        KERAS: keras==2.3.1
         TENSORFLOW_PATH: tensorflow==2.0.0
         INSTALL_ORT:
 


### PR DESCRIPTION
keras 2.4.0 released to pypi today (6/17/2020) which installs tensorflow 2.x, then it breaks nightly build for tf 1.x case. Pin keras==2.3.1 accordingly.