### PR TITLE
Fix tf.keras.layers.Softmax conversion

### DIFF
--- a/keras2onnx/parser.py
+++ b/keras2onnx/parser.py
@@ -602,6 +602,9 @@ def _parse_graph_core(graph, keras_node_dict, topology, top_scope, output_names)
                            layer_key_ else (nodes[0].name, "Custom_Layer"))
         if isinstance(layer_key_, keras.layers.TimeDistributed):
             _on_parsing_time_distributed_layer(graph, nodes, layer_key_, model_, varset)
+        elif isinstance(layer_key_, keras.layers.Softmax):
+            # tf.keras.layers.Softmax have Transpose ops to swap axis.
+            _on_parsing_tf_nodes(graph, nodes, varset, topology.debug_mode)
         elif layer_key_ is None or get_converter(type(layer_key_)) is None:
             _on_parsing_tf_nodes(graph, nodes, varset, topology.debug_mode)
         else:
@@ -723,6 +726,10 @@ def _parse_graph_core_v2(graph, keras_node_dict, topology, top_scope, output_nam
                            layer_info.layer else (layer_info.nodelist[0].name, "Custom_Layer"))
         if layer_info.layer and isinstance(layer_info.layer, keras.layers.TimeDistributed):
             _on_parsing_time_distributed_layer(graph, layer_info.nodelist, layer_info.layer, model_, varset)
+        elif layer_info.layer and isinstance(layer_info.layer, keras.layers.Softmax)\
+                and sum([1 if n_.type == 'Transpose' else 0 for n_ in layer_info.nodelist]) > 0:
+            # tf.keras.layers.Softmax have Transpose ops to swap axis.
+            _on_parsing_tf_nodes(graph, layer_info.nodelist, varset, topology.debug_mode)
         elif layer_info.layer and get_converter(type(layer_info.layer)):
             on_parsing_keras_layer_v2(graph, layer_info, varset)
         else:

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1373,6 +1373,17 @@ def test_Softmax(advanced_activation_runner):
     advanced_activation_runner(layer, data)
 
 
+def test_Softmax_2(runner):
+    keras.backend.set_image_data_format("channels_first")
+    model = keras.Sequential()
+    model.add(keras.layers.InputLayer((2, 4, 4)))
+    model.add(keras.layers.Softmax(axis=1))
+    data = np.random.rand(1, 2, 4, 4).astype(np.float32)
+    onnx_model = keras2onnx.convert_keras(model, model.name)
+    expected = model.predict(data)
+    assert runner(onnx_model.graph.name, onnx_model, data, expected)
+
+
 @pytest.mark.skipif(is_tensorflow_older_than('1.14.0') and is_tf_keras, reason='old tf version')
 def test_tf_nn_activation(runner):
     for activation in ['relu', tf.nn.relu, tf.nn.relu6, tf.nn.softmax, tf.nn.leaky_relu]:
@@ -2399,7 +2410,8 @@ def test_sub_model(runner):
 
     model = Sequential()  # 28, 28, 1
     model.add(Conv2D(32, kernel_size=(3, 3), activation='relu',
-                     input_shape=input_shape, padding='valid'))  # 28, 28, 1
+                     input_shape=input_shape, padding='valid',
+                     data_format='channels_last'))  # 28, 28, 1
     model.add(Conv2D(64, (3, 3), activation='relu', padding='valid'))  # 28, 28, 1
     model.add(MaxPooling2D(pool_size=(2, 2), strides=(2, 2), padding="valid"))  # 14, 14, 1
     model.add(Dropout(0.25))


### PR DESCRIPTION
See the [issue](https://github.com/onnx/keras-onnx/issues/529). Currently we just convert it using keras conversion, the problem is that keras Softmax behaves differently with onnx Softmax except axis=-1. We need swap axis with the last dim, like what it did in tensorflow.keras code.