### PR TITLE
Convert keras activation from activation_map

### DIFF
--- a/keras2onnx/ke2onnx/activation.py
+++ b/keras2onnx/ke2onnx/activation.py
@@ -92,6 +92,8 @@ def convert_keras_activation(scope, operator, container):
     elif hasattr(activation, '__name__') and activation.__name__ == 'swish':
         apply_sigmoid(scope, input_name, output_name + '_sig', container)
         apply_mul(scope, [input_name, output_name + '_sig'], output_name, container)
+    elif activation in activation_map:
+        activation_map[activation](scope, input_name, output_name, container)
     else:
         if activation in [activation_get('softsign'), keras.activations.softsign]:
             op_type = 'Softsign'


### PR DESCRIPTION
Converting a deeplab v3 [model](https://github.com/bonlime/keras-deeplab-v3-plus). This model uses `x = Activation(tf.nn.relu)(x)`, the activation function is from tf not keras. Our original code does not consider this case. So we use `activation_map` do a further handling.