### PR TITLE
parser: filter the input "conv_7b_bn/cond/input"

### DIFF
--- a/applications/nightly_build/test_keras_applications_v2.py
+++ b/applications/nightly_build/test_keras_applications_v2.py
@@ -58,7 +58,7 @@ class TestKerasApplications(unittest.TestCase):
         self.assertTrue(*res)
     
     def test_InceptionResNetV2(self):
-        InceptionResNetV2 = keras.applications.inception_resnet_v2
+        InceptionResNetV2 = keras.applications.inception_resnet_v2.InceptionResNetV2
         model = InceptionResNetV2(include_top=True)
         res = run_image(model, self.model_files, img_path, target_size=299, tf_v2=True)
         self.assertTrue(*res)

--- a/applications/nightly_build/test_keras_applications_v2.py
+++ b/applications/nightly_build/test_keras_applications_v2.py
@@ -56,6 +56,12 @@ class TestKerasApplications(unittest.TestCase):
         model = InceptionV3(include_top=True)
         res = run_image(model, self.model_files, img_path, target_size=299, tf_v2=True)
         self.assertTrue(*res)
+    
+    def test_InceptionResNetV2(self):
+        InceptionResNetV2 = keras.applications.inception_resnet_v2
+        model = InceptionResNetV2(include_top=True)
+        res = run_image(model, self.model_files, img_path, target_size=299, tf_v2=True)
+        self.assertTrue(*res)
 
     def test_ResNet50(self):
         ResNet50 = keras.applications.resnet_v2.ResNet50V2

--- a/keras2onnx/parser.py
+++ b/keras2onnx/parser.py
@@ -490,7 +490,6 @@ def _filter_out_input(node_name):
         r"batch_normalization_\d+\/scale$",
         r"batch_normalization_\d+\/cond/input",
         # inception_resnet_v2 has a name "conv_7b_bn" for a BN layer, just fixes by filtering.
-        # see: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/keras/applications/inception_resnet_v2.py#L203
         r"conv_7b_bn/cond/input"
     ]
     filter_out = False

--- a/keras2onnx/parser.py
+++ b/keras2onnx/parser.py
@@ -486,7 +486,13 @@ def _filter_out_input(node_name):
     # tf.keras BN layer sometimes create a placeholder node 'scale' in tf 2.x.
     # It creates 'cond/input' since tf 2.2.
     # Given bn layer will be converted in a whole layer, it's fine to just filter this node out.
-    filter_patterns = [r"batch_normalization_\d+\/scale$", r"batch_normalization_\d+\/cond/input"]
+    filter_patterns = [
+        r"batch_normalization_\d+\/scale$",
+        r"batch_normalization_\d+\/cond/input",
+        # inception_resnet_v2 has a name "conv_7b_bn" for a BN layer, just fixes by filtering.
+        # see: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/keras/applications/inception_resnet_v2.py#L203
+        r"conv_7b_bn/cond/input"
+    ]
     filter_out = False
     for pattern_ in filter_patterns:
         filter_out = filter_out or re.match(pattern_, node_name)

--- a/keras2onnx/parser.py
+++ b/keras2onnx/parser.py
@@ -490,7 +490,7 @@ def _filter_out_input(node_name):
         r"batch_normalization_\d+\/scale$",
         r"batch_normalization_\d+\/cond/input",
         # inception_resnet_v2 has a name "conv_7b_bn" for a BN layer, just fixes by filtering.
-        r"conv_7b_bn/cond/input"
+        r"conv_\d+b_bn/cond/input"
     ]
     filter_out = False
     for pattern_ in filter_patterns:


### PR DESCRIPTION
This is to fix an error when converting an inception_resnet_v2 Keras model to ONNX:

```
AssertionError: conv_7b_bn/cond/input_0:01 is disconnected, check the parsing log for more details.
```

After investigating some background, I found inception_resnet_v2 has a name "conv_7b_bn" for a BN layer, just fixes by filtering as we do filter for "batch_normalization".

See [tensorflow/python/keras/applications/inception_resnet_v2.py](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/keras/applications/inception_resnet_v2.py#L203), which defined a custom `conv_7b_bn` for a specific BN layer.