### PR TITLE
Handle multiple inputs for keras.layers.Average

### DIFF
--- a/keras2onnx/common/intop.py
+++ b/keras2onnx/common/intop.py
@@ -31,7 +31,6 @@ class Operator:
         self.is_evaluated = None
         self.target_opset = target_opset
         self.shape_infer = None
-        self.tf2onnx_graph = None
         self.attrs = {}
 
     @property

--- a/keras2onnx/ke2onnx/main.py
+++ b/keras2onnx/ke2onnx/main.py
@@ -180,6 +180,7 @@ keras_layer_to_operator = {
     _layer.Subtract: convert_keras_merge_layer,
     _layer.Average: convert_keras_merge_layer,
     _layer.Maximum: convert_keras_merge_layer,
+    _layer.Minimum: convert_keras_merge_layer,
     _layer.Concatenate: convert_keras_concat,
 
     _layer.Dense: convert_keras_dense,


### PR DESCRIPTION
Converting a ExpantionSuperResolution model [here](https://github.com/titu1994/Image-Super-Resolution). The `keras.layers.Average` has three inputs, the original code processes it progressively every two, so it will be mean(mean(A, B), C), then it is wrong. We fix it in this PR.

Also deprecate `tf2onnx_graph` in common intop.