### PR TITLE
Support tf.LinSpace and tf.AddN conversion

### DIFF
--- a/keras2onnx/_builtin.py
+++ b/keras2onnx/_builtin.py
@@ -36,10 +36,10 @@ def convert_tf_identity(scope, operator, container):
 @converter_func(TYPES.AddN)
 def convert_tf_addn(scope, operator, container):
     oopb = OnnxOperatorBuilder(container, scope)
-    oopb.apply_op_with_output("apply_add",
+    oopb.apply_op_with_output("apply_sum",
                               operator.input_full_names,
                               operator.output_full_names,
-                              name=operator.full_name + '_add')
+                              name=operator.full_name + '_sum')
 
 
 def _convert_tf_argmax_argmin_helper(scope, operator, container, arg_str):
@@ -966,6 +966,37 @@ def convert_tf_greater_equal(scope, operator, container):
 def convert_tf_less_equal(scope, operator, container):
     oopb = OnnxOperatorBuilder(container, scope)
     oopb.apply_op_with_output('apply_less_or_equal', operator.input_full_names,
+                              operator.output_full_names,
+                              name=operator.full_name)
+
+
+@converter_func(TYPES.LinSpace)
+def convert_tf_linspace(scope, operator, container):
+    node = operator.raw_operator
+    oopb = OnnxOperatorBuilder(container, scope)
+    sub_value = oopb.apply_sub([operator.input_full_names[1], operator.input_full_names[0]],
+                               name=operator.full_name + '_sub')
+    sub_1_value = oopb.apply_sub([operator.input_full_names[2],
+                                  ('_minus_one', _to_onnx_type(node.inputs[2].dtype),
+                                   np.array(1, dtype=node.inputs[2].dtype.name))],
+                                 name=operator.full_name + '_sub_1')
+    cast_sub_1 = oopb.apply_cast(sub_1_value,
+                                 to=_to_onnx_type(node.inputs[0].dtype),
+                                 name=operator.full_name + '_sub_1_cast')
+    div_value = oopb.apply_div(sub_value + cast_sub_1,
+                               name=operator.full_name + '_div')
+
+    if _to_onnx_type(node.inputs[1].dtype) in [oopb.float, oopb.double, oopb.float16]:
+        delta_value = 0.0000001
+    else:
+        delta_value = 1
+    add_delta_value = oopb.apply_add([operator.input_full_names[1],
+                                      ('_add_delta', _to_onnx_type(node.inputs[1].dtype),
+                                       np.array(delta_value, dtype=node.inputs[1].dtype.name))],
+                                     name=operator.full_name + '_add_delta')
+
+    oopb.add_node_with_output('Range',
+                              [operator.input_full_names[0]] + add_delta_value + div_value,
                               operator.output_full_names,
                               name=operator.full_name)
 

--- a/keras2onnx/_consts.py
+++ b/keras2onnx/_consts.py
@@ -46,6 +46,7 @@ class TYPES:
     GreaterEqual = 'GreaterEqual'
     IdentityN = 'IdentityN'
     LessEqual = 'LessEqual'
+    LinSpace = 'LinSpace'
     LogicalAnd = 'LogicalAnd'
     LogicalNot = 'LogicalNot'
     LogSoftmax = 'LogSoftmax'


### PR DESCRIPTION
Converting a keras-ocr model [here](https://github.com/faustomorales/keras-ocr/), and this PR helps conversion successfully.
keras-ocr ping the certain version efficientnet 1.0.0, so we are not putting into nightly build (we use latest efficientnet for testing).