### PR TITLE
Support for recurrent_v2 layers for TF 2.0

### DIFF
--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -71,6 +71,11 @@ if not is_keras_older_than("2.2.4"):
 
 RNN_CLASSES = [SimpleRNN, GRU, LSTM]
 
+if is_tf_keras and is_tensorflow_later_than("1.14.0"):
+    # Add the TF v2 compatability layers (available after TF 1.14)
+    from tensorflow.python.keras.layers import recurrent_v2
+    RNN_CLASSES.extend([recurrent_v2.GRU, recurrent_v2.LSTM])
+
 
 def _asarray(*a):
     return np.array([a], dtype='f')


### PR DESCRIPTION
In #607, it was observed that TensorFlow versions before 2.0 can have problems converting TF 2.0 compatible models because the classes are expected to be the previous API. For example in TF 1.14 the v2 compatible classes are present in `tensorflow.keras.layers.recurrent_v2`, but do not match `tensorflow.keras.layers`. This PR resolves #607 by adding support for these layers. For versions of TensorFlow that are above 2.0, this is not a problem because `tensorflow.keras.layers` uses the v2 layers.

This strategy is tested by expanding the `RNN_CLASSES` list in the tests, so that `recurrent_v2` classes are tested if present.