### PR TITLE
Fix tf.keras CI build on RNN recurrent_v2

### DIFF
--- a/keras2onnx/ke2onnx/main.py
+++ b/keras2onnx/ke2onnx/main.py
@@ -4,8 +4,7 @@
 # license information.
 ###############################################################################
 import numpy as np
-from ..proto import keras, is_tf_keras, is_keras_older_than
-from ..proto.tfcompat import is_tf2
+from ..proto import keras, is_tf_keras, is_keras_older_than, is_tensorflow_later_than
 from ..common import with_variable, k2o_logger
 from ..common.onnx_ops import OnnxOperatorBuilder
 
@@ -261,7 +260,7 @@ if not is_keras_older_than('2.2.0'):
         _adv_activations.ReLU: convert_keras_advanced_activation,
     })
 
-if is_tf_keras and is_tf2:
+if is_tf_keras and is_tensorflow_later_than("1.14.0"):
     keras_layer_to_operator.update({
         _layer.recurrent.GRU: convert_keras_gru,
         _layer.recurrent.LSTM: convert_keras_lstm,

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -2122,7 +2122,6 @@ def test_bidirectional_seqlen_none(runner, rnn_class):
         assert runner(onnx_model.graph.name, onnx_model, x, expected)
 
 
-@pytest.mark.skipif(is_tf2, reason='TODO')
 @pytest.mark.parametrize("rnn_class", RNN_CLASSES)
 def test_rnn_state_passing(runner, rnn_class):
     input1 = Input(shape=(None, 5))


### PR DESCRIPTION
The [PR](https://github.com/onnx/keras-onnx/pull/610) lacks the change on registering RNN recurrent_v2 conversion, so it causes linux-tf-keras-ci failure on py36 case [here](https://dev.azure.com/onnxmltools/ketone/_build/results?buildId=16396&view=logs&j=d7d66435-5ae4-561a-5876-2cd4e19b3ce2) when tensorflow==1.15.0. 

This PR fixes it. 

I also find `test_rnn_state_passing` passes for tf 2.3 locally, so enable this test in CI build.