### PR TITLE
Fix for export using TF2.3.1

### DIFF
--- a/keras2onnx/proto/tfcompat.py
+++ b/keras2onnx/proto/tfcompat.py
@@ -10,9 +10,9 @@ is_tf2 = StrictVersion(_tf.__version__.split('-')[0]) >= StrictVersion('2.0.0')
 
 def normalize_tensor_shape(tensor_shape):
     if is_tf2:
-        return [d for d in tensor_shape]
-    else:
         return [d.value for d in tensor_shape]
+    else:
+        return [d for d in tensor_shape]
 
 
 def dump_graph_into_tensorboard(tf_graph):


### PR DESCRIPTION
This logic seems to be reversed and is preventing converting TensorFlow 2.3 models.

See [#659](https://github.com/onnx/keras-onnx/issues/659)