### PR TITLE
Pip install Pillow<=8.2.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 numpy<=1.19.5
-pillow
+pillow<=8.2.0
 pytest
 onnxruntime
 coverage


### PR DESCRIPTION
Pillow 8.3.0 breaks the pipeline.